### PR TITLE
refactor: rename cash flow to budget, surplus to remaining; chore: bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build backend
-FROM rust:1.80-slim AS backend-builder
+FROM rust:1.83-slim AS backend-builder
 WORKDIR /build
 COPY backend/Cargo.toml backend/Cargo.lock* ./
 RUN mkdir src && echo 'fn main(){}' > src/main.rs && cargo build --release 2>/dev/null || true && rm -rf src
@@ -7,7 +7,7 @@ COPY backend/src ./src
 RUN touch src/main.rs && cargo build --release
 
 # Stage 2: Build frontend
-FROM node:20-slim AS frontend-builder
+FROM node:22-slim AS frontend-builder
 WORKDIR /build
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm install

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -429,7 +429,7 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
             }
             links.push(SankeyLink {
                 source: name.clone(),
-                target: "Cash Flow".to_string(),
+                target: "Budget".to_string(),
                 value: monthly,
             });
             income_total += monthly;
@@ -448,9 +448,9 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
     }
 
     // Add Cash Flow node
-    if node_ids.insert("Cash Flow".to_string()) {
+    if node_ids.insert("Budget".to_string()) {
         nodes.push(SankeyNode {
-            id: "Cash Flow".to_string(),
+            id: "Budget".to_string(),
         });
     }
 
@@ -461,7 +461,7 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
             nodes.push(SankeyNode { id: tag.clone() });
         }
         links.push(SankeyLink {
-            source: "Cash Flow".to_string(),
+            source: "Budget".to_string(),
             target: tag.clone(),
             value: *amount,
         });
@@ -472,11 +472,11 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
     let diff = income_total - expense_total;
     if diff > 0.0 {
         nodes.push(SankeyNode {
-            id: "Surplus".to_string(),
+            id: "Remaining".to_string(),
         });
         links.push(SankeyLink {
-            source: "Cash Flow".to_string(),
-            target: "Surplus".to_string(),
+            source: "Budget".to_string(),
+            target: "Remaining".to_string(),
             value: diff,
         });
     } else if diff < 0.0 {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,17 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
-    "react-router-dom": "^6.26.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
     "@nivo/sankey": "^0.87.0",
-    "@phosphor-icons/react": "^2.1.0"
+    "@phosphor-icons/react": "^2.1.7"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5"
   }
 }

--- a/frontend/src/components/BudgetDiagram.tsx
+++ b/frontend/src/components/BudgetDiagram.tsx
@@ -1,8 +1,6 @@
-
 import React, { useEffect, useState } from 'react';
 import { ResponsiveSankey } from '@nivo/sankey';
 import type { SankeyData } from '../types';
-
 
 interface Props {
   data: SankeyData;
@@ -22,7 +20,7 @@ const SankeyTooltip = ({ link }: { link: any }) => {
       }}
     >
       <strong>{link.source.label} → {link.target.label}</strong>
-      <div style={{ color: 'var(--color-muted)' }}>
+      <div style={{ color: 'var(--color-text-secondary)' }}>
         ${link.value.toLocaleString()}
       </div>
     </div>
@@ -43,7 +41,7 @@ const nivoTheme = {
   },
 };
 
-export default function CashflowDiagram({ data }: Props) {
+export default function BudgetDiagram({ data }: Props) {
   const [themeKey, setThemeKey] = useState(0);
 
   useEffect(() => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { fetchCashflow } from '../api';
 import type { SankeyData } from '../types';
-import CashflowDiagram from '../components/CashflowDiagram';
+import BudgetDiagram from '../components/BudgetDiagram';
 import UpcomingBillsSidebar from '../components/UpcomingBillsSidebar';
 
 export default function Dashboard() {
@@ -13,14 +13,14 @@ export default function Dashboard() {
 
   return (
     <>
-      <h1 style={{ marginBottom: 24 }}>Monthly Cash Flow</h1>
+      <h1 style={{ marginBottom: 24 }}>Monthly Budget</h1>
       <div className="dashboard">
         <div className="dashboard-main">
           {data && data.nodes.length > 0 ? (
-            <CashflowDiagram data={data} />
+            <BudgetDiagram data={data} />
           ) : (
             <div className="empty-state">
-              <p>No budget items yet. Add income and expenses to see your cash flow.</p>
+              <p>No budget items yet. Add income and expenses to see your monthly budget.</p>
             </div>
           )}
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -18,9 +18,11 @@
   --color-expense: #ef4444;
   --color-surplus: #22c55e;
   --color-deficit: #ef4444;
+  --color-node-deficit: #ef4444;
   --color-primary: #6366f1;
   --color-primary-hover: #4f46e5;
   --color-primary-light: #eef2ff;
+  --color-remaining: #22c55e;
   --radius: 12px;
   --radius-sm: 8px;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
@@ -38,9 +40,11 @@
   --color-expense: #f87171;
   --color-surplus: #4ade80;
   --color-deficit: #f87171;
+  --color-node-deficit: #f87171;
   --color-primary: #818cf8;
   --color-primary-hover: #6366f1;
   --color-primary-light: #1e1b4b;
+  --color-remaining: #4ade80;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.4);
 }


### PR DESCRIPTION
This PR renames all references of 'cash flow' to 'budget' and 'surplus' to 'remaining' for clarity in the Sankey diagram and related UI. Also bumps dependencies in package.json and Dockerfile.
- Refactor: terminology update for clarity
- Chore: dependency updates\n\nValidation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend
Follows contribution guidelines for branch naming, commit style, and PR process.