### PR TITLE
feat: add theme support and initial themes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,45 +1,50 @@
-import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
-import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon } from '@phosphor-icons/react';
-import Dashboard from './pages/Dashboard';
-import BudgetItems from './pages/BudgetItems';
-import Summary from './pages/Summary';
-import Tags from './pages/Tags';
-import ThemeToggle from './components/ThemeToggle';
+import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
+import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon } from '@phosphor-icons/react'
+import Dashboard from './pages/Dashboard'
+import BudgetItems from './pages/BudgetItems'
+import Summary from './pages/Summary'
+import Tags from './pages/Tags'
+import ThemeToggle from './components/ThemeToggle'
+import ThemeSelector from './components/ThemeSelector'
+import { ThemeProvider } from './context/ThemeContext'
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <div className="app">
-        <nav className="nav">
-          <div className="nav-brand">
-            <img src="/icon-192.png" alt="" aria-hidden="true" />
-            Budget Overview
-          </div>
-          <div className="nav-links">
-            <NavLink to="/" end>
-              <HouseIcon size={20} /> Dashboard
-            </NavLink>
-            <NavLink to="/items">
-              <ListBulletsIcon size={20} /> Items
-            </NavLink>
-            <NavLink to="/summary">
-              <ChartBarIcon size={20} /> Summary
-            </NavLink>
-            <NavLink to="/tags">
-              <TagIcon size={20} /> Tags
-            </NavLink>
-          </div>
-          <ThemeToggle />
-        </nav>
-        <main className="main">
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/items" element={<BudgetItems />} />
-            <Route path="/summary" element={<Summary />} />
-            <Route path="/tags" element={<Tags />} />
-          </Routes>
-        </main>
-      </div>
-    </BrowserRouter>
-  );
+    <ThemeProvider>
+      <BrowserRouter>
+        <div className="app">
+          <nav className="nav">
+            <div className="nav-brand">
+              <img src="/icon-192.png" alt="" aria-hidden="true" />
+              Budget Overview
+            </div>
+            <div className="nav-links">
+              <NavLink to="/" end>
+                <HouseIcon size={20} /> Dashboard
+              </NavLink>
+              <NavLink to="/items">
+                <ListBulletsIcon size={20} /> Items
+              </NavLink>
+              <NavLink to="/summary">
+                <ChartBarIcon size={20} /> Summary
+              </NavLink>
+              <NavLink to="/tags">
+                <TagIcon size={20} /> Tags
+              </NavLink>
+            </div>
+            <ThemeSelector />
+            <ThemeToggle />
+          </nav>
+          <main className="main">
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/items" element={<BudgetItems />} />
+              <Route path="/summary" element={<Summary />} />
+              <Route path="/tags" element={<Tags />} />
+            </Routes>
+          </main>
+        </div>
+      </BrowserRouter>
+    </ThemeProvider>
+  )
 }

--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { CaretDownIcon, CheckIcon } from '@phosphor-icons/react'
+import { useTheme } from '../context/ThemeContext'
+import type { ThemeDefinition } from '../themes/types'
+
+function ThemePreview({ theme, mode }: { theme: ThemeDefinition; mode: 'light' | 'dark' }) {
+  const palette = theme.palettes[mode]
+
+  return (
+    <span
+      className="theme-preview"
+      aria-hidden="true"
+      style={{
+        '--preview-border': palette.border,
+        '--preview-surface': palette.surface,
+        '--preview-accent': palette.accent,
+      } as React.CSSProperties}
+    >
+      <span className="theme-preview-box">
+        <span className="theme-preview-dot" />
+      </span>
+    </span>
+  )
+}
+
+export default function ThemeSelector() {
+  const { themes, selectedTheme, setThemeId, mode } = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  useEffect(() => {
+    const idx = themes.findIndex(t => t.id === selectedTheme.id)
+    setActiveIndex(idx === -1 ? 0 : idx)
+  }, [themes, selectedTheme.id])
+
+  useEffect(() => {
+    if (!isOpen) return
+    optionRefs.current[activeIndex]?.focus()
+  }, [isOpen, activeIndex])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (e: MouseEvent) => {
+      if (!dropdownRef.current?.contains(e.target as Node)) setIsOpen(false)
+    }
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { setIsOpen(false); triggerRef.current?.focus() }
+    }
+
+    window.addEventListener('mousedown', handlePointerDown)
+    window.addEventListener('keydown', handleEscape)
+    return () => {
+      window.removeEventListener('mousedown', handlePointerDown)
+      window.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen])
+
+  return (
+    <div className="theme-selector" ref={dropdownRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="theme-selector-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => {
+          setIsOpen(prev => {
+            if (!prev) {
+              const idx = themes.findIndex(t => t.id === selectedTheme.id)
+              setActiveIndex(idx === -1 ? 0 : idx)
+            }
+            return !prev
+          })
+        }}
+        onKeyDown={e => {
+          if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault()
+            const idx = themes.findIndex(t => t.id === selectedTheme.id)
+            setActiveIndex(idx === -1 ? 0 : idx)
+            setIsOpen(true)
+          }
+        }}
+      >
+        <ThemePreview theme={selectedTheme} mode={mode} />
+        <span className="theme-selector-label">{selectedTheme.name}</span>
+        <CaretDownIcon className="theme-selector-caret" weight="bold" aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <ul className="theme-selector-menu" role="listbox" aria-label="Choose theme">
+          {themes.map((theme, index) => {
+            const isSelected = theme.id === selectedTheme.id
+            return (
+              <li key={theme.id} role="option" aria-selected={isSelected}>
+                <button
+                  ref={el => { optionRefs.current[index] = el }}
+                  type="button"
+                  className={`theme-selector-option ${isSelected ? 'is-active' : ''}`}
+                  tabIndex={index === activeIndex ? 0 : -1}
+                  onClick={() => { setThemeId(theme.id); setIsOpen(false); triggerRef.current?.focus() }}
+                  onKeyDown={e => {
+                    if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIndex(p => (p + 1) % themes.length) }
+                    if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIndex(p => (p - 1 + themes.length) % themes.length) }
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setThemeId(theme.id); setIsOpen(false); triggerRef.current?.focus() }
+                    if (e.key === 'Escape') { e.preventDefault(); setIsOpen(false); triggerRef.current?.focus() }
+                  }}
+                >
+                  <span className="theme-selector-option-main">
+                    <ThemePreview theme={theme} mode={mode} />
+                    <span className="theme-selector-option-name">{theme.name}</span>
+                  </span>
+                  {isSelected && <CheckIcon className="theme-selector-option-check" weight="bold" aria-hidden="true" />}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,25 +1,16 @@
-import { useState, useEffect } from 'react';
-import { Moon, Sun } from '@phosphor-icons/react';
+import { MoonIcon, SunIcon } from '@phosphor-icons/react'
+import { useTheme } from '../context/ThemeContext'
 
 export default function ThemeToggle() {
-  const [dark, setDark] = useState(() => {
-    const saved = localStorage.getItem('theme');
-    if (saved) return saved === 'dark';
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
-  });
-
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
-    localStorage.setItem('theme', dark ? 'dark' : 'light');
-  }, [dark]);
+  const { mode, toggleMode } = useTheme()
 
   return (
     <button
       className="btn-icon theme-toggle"
-      onClick={() => setDark((d) => !d)}
+      onClick={toggleMode}
       aria-label="Toggle theme"
     >
-      {dark ? <Sun size={22} /> : <Moon size={22} />}
+      {mode === 'dark' ? <SunIcon size={22} /> : <MoonIcon size={22} />}
     </button>
-  );
+  )
 }

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,79 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { themes } from '../themes'
+import { applyTheme } from '../themes/themeManager'
+import type { ThemeDefinition, ThemeMode } from '../themes/types'
+
+const MODE_STORAGE_KEY = 'budget_mode'
+const THEME_STORAGE_KEY = 'budget_theme'
+const DEFAULT_THEME_ID = 'default'
+
+interface ThemeContextValue {
+  themes: ThemeDefinition[]
+  mode: ThemeMode
+  setMode: (mode: ThemeMode) => void
+  toggleMode: () => void
+  themeId: string
+  setThemeId: (id: string) => void
+  selectedTheme: ThemeDefinition
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+const readStoredMode = (): ThemeMode | null => {
+  try {
+    const value = window.localStorage.getItem(MODE_STORAGE_KEY)
+    return value === 'light' || value === 'dark' ? value : null
+  } catch {
+    return null
+  }
+}
+
+const readStoredThemeId = (): string | null => {
+  try {
+    const value = window.localStorage.getItem(THEME_STORAGE_KEY)
+    return themes.some(t => t.id === value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+const getInitialMode = (): ThemeMode => {
+  const stored = readStoredMode()
+  if (stored) return stored
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  } catch {
+    return 'light'
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>(getInitialMode)
+  const [themeId, setThemeId] = useState(() => readStoredThemeId() || DEFAULT_THEME_ID)
+
+  useEffect(() => {
+    const selectedTheme = themes.find(t => t.id === themeId) || themes[0]
+    applyTheme(selectedTheme, mode)
+
+    try {
+      window.localStorage.setItem(MODE_STORAGE_KEY, mode)
+      window.localStorage.setItem(THEME_STORAGE_KEY, selectedTheme.id)
+    } catch {
+      // ignore storage failures in private/restricted browsing modes
+    }
+  }, [mode, themeId])
+
+  const value = useMemo(() => {
+    const selectedTheme = themes.find(t => t.id === themeId) || themes[0]
+    const toggleMode = () => setMode(prev => (prev === 'dark' ? 'light' : 'dark'))
+    return { themes, mode, setMode, toggleMode, themeId, setThemeId, selectedTheme }
+  }, [mode, themeId])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) throw new Error('useTheme must be used within ThemeProvider')
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles.css';
+import { themes } from './themes';
+import { applyTheme } from './themes/themeManager';
+import type { ThemeMode } from './themes/types';
+
+const storedMode = localStorage.getItem('budget_mode')
+const storedThemeId = localStorage.getItem('budget_theme')
+const initialMode: ThemeMode = storedMode === 'light' || storedMode === 'dark'
+  ? storedMode
+  : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+const initialTheme = themes.find(t => t.id === storedThemeId) || themes[0]
+applyTheme(initialTheme, initialMode)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -796,6 +796,119 @@ body {
 }
 
 /* ============================================================
+   THEME SELECTOR
+   ============================================================ */
+
+.theme-selector {
+  position: relative;
+}
+
+.theme-selector-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.theme-selector-trigger:hover {
+  background: var(--color-canvas);
+}
+
+.theme-selector-label {
+  white-space: nowrap;
+}
+
+.theme-selector-caret {
+  width: 12px;
+  height: 12px;
+  color: var(--color-text-muted);
+}
+
+.theme-selector-menu {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  min-width: 180px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  list-style: none;
+  padding: var(--space-1) 0;
+  z-index: 200;
+}
+
+.theme-selector-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition);
+  text-align: left;
+}
+
+.theme-selector-option:hover,
+.theme-selector-option.is-active {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
+}
+
+.theme-selector-option-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.theme-selector-option-check {
+  width: 14px;
+  height: 14px;
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.theme-preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.theme-preview-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 20px;
+  border-radius: 4px;
+  border: 1px solid var(--preview-border, var(--color-border));
+  background: var(--preview-surface, var(--color-surface));
+}
+
+.theme-preview-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--preview-accent, var(--color-accent));
+}
+
+/* ============================================================
    RESPONSIVE
    ============================================================ */
 

--- a/frontend/src/themes/budgetDefaultTheme.ts
+++ b/frontend/src/themes/budgetDefaultTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const budgetDefaultTheme: ThemeDefinition = {
+  id: 'default',
+  name: 'Default',
+  palettes: {
+    light: {
+      canvas:       '#f8fafc',
+      surface:      '#ffffff',
+      textInverse:  '#ffffff',
+      text:         '#1e293b',
+      textMuted:    '#475569',
+      border:       '#e2e8f0',
+      accent:       '#1d4ed8',
+      accentHover:  '#1e40af',
+      accentSubtle: '#eff6ff',
+      positive:     '#15803d',
+      negative:     '#b91c1c',
+    },
+    dark: {
+      canvas:       '#0f172a',
+      surface:      '#1e293b',
+      textInverse:  '#ffffff',
+      text:         '#f1f5f9',
+      textMuted:    '#94a3b8',
+      border:       '#334155',
+      accent:       '#60a5fa',
+      accentHover:  '#3b82f6',
+      accentSubtle: '#1e3a5f',
+      positive:     '#4ade80',
+      negative:     '#f87171',
+    },
+  },
+}

--- a/frontend/src/themes/catppuccinTheme.ts
+++ b/frontend/src/themes/catppuccinTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const catppuccinTheme: ThemeDefinition = {
+  id: 'catppuccin',
+  name: 'Catppuccin',
+  palettes: {
+    light: {
+      canvas:       '#EFF1F5',
+      surface:      '#E6E9EF',
+      textInverse:  '#EFF1F5',
+      text:         '#4C4F69',
+      textMuted:    '#6C6F85',
+      border:       '#BCC0CC',
+      accent:       '#1E66F5',
+      accentHover:  '#1553CC',
+      accentSubtle: '#DCE0F5',
+      positive:     '#40A02B',
+      negative:     '#D20F39',
+    },
+    dark: {
+      canvas:       '#1E1E2E',
+      surface:      '#181825',
+      textInverse:  '#1E1E2E',
+      text:         '#CDD6F4',
+      textMuted:    '#A6ADC8',
+      border:       '#45475A',
+      accent:       '#89B4FA',
+      accentHover:  '#74A0F6',
+      accentSubtle: '#2A3555',
+      positive:     '#A6E3A1',
+      negative:     '#F38BA8',
+    },
+  },
+}

--- a/frontend/src/themes/everforestTheme.ts
+++ b/frontend/src/themes/everforestTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const everforestTheme: ThemeDefinition = {
+  id: 'everforest',
+  name: 'Everforest',
+  palettes: {
+    light: {
+      canvas:       '#FDF6E3',
+      surface:      '#F4F0D9',
+      textInverse:  '#FDF6E3',
+      text:         '#5C6A72',
+      textMuted:    '#829181',
+      border:       '#BDC3AF',
+      accent:       '#3A94C5',
+      accentHover:  '#2E7BA8',
+      accentSubtle: '#E2EEF5',
+      positive:     '#8DA101',
+      negative:     '#F85552',
+    },
+    dark: {
+      canvas:       '#2D353B',
+      surface:      '#343F44',
+      textInverse:  '#2D353B',
+      text:         '#D3C6AA',
+      textMuted:    '#9DA9A0',
+      border:       '#4F585E',
+      accent:       '#7FBBB3',
+      accentHover:  '#6AA8A0',
+      accentSubtle: '#2E4048',
+      positive:     '#A7C080',
+      negative:     '#E67E80',
+    },
+  },
+}

--- a/frontend/src/themes/gruvboxTheme.ts
+++ b/frontend/src/themes/gruvboxTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const gruvboxTheme: ThemeDefinition = {
+  id: 'gruvbox',
+  name: 'Gruvbox',
+  palettes: {
+    light: {
+      canvas:       '#fbf1c7',
+      surface:      '#f2e5bc',
+      textInverse:  '#fbf1c7',
+      text:         '#3c3836',
+      textMuted:    '#665c54',
+      border:       '#bdae93',
+      accent:       '#458588',
+      accentHover:  '#367374',
+      accentSubtle: '#d5e8e8',
+      positive:     '#98971a',
+      negative:     '#cc241d',
+    },
+    dark: {
+      canvas:       '#282828',
+      surface:      '#3c3836',
+      textInverse:  '#282828',
+      text:         '#ebdbb2',
+      textMuted:    '#bdae93',
+      border:       '#504945',
+      accent:       '#83a598',
+      accentHover:  '#6d9186',
+      accentSubtle: '#2d3f3e',
+      positive:     '#b8bb26',
+      negative:     '#fb4934',
+    },
+  },
+}

--- a/frontend/src/themes/index.ts
+++ b/frontend/src/themes/index.ts
@@ -1,0 +1,27 @@
+import { budgetDefaultTheme } from './budgetDefaultTheme'
+import { nordTheme } from './nordTheme'
+import { catppuccinTheme } from './catppuccinTheme'
+import { everforestTheme } from './everforestTheme'
+import { gruvboxTheme } from './gruvboxTheme'
+import { solarizedTheme } from './solarizedTheme'
+import { scienceTheme } from './scienceTheme'
+
+export {
+  budgetDefaultTheme,
+  nordTheme,
+  catppuccinTheme,
+  everforestTheme,
+  gruvboxTheme,
+  solarizedTheme,
+  scienceTheme,
+}
+
+export const themes = [
+  budgetDefaultTheme,
+  nordTheme,
+  catppuccinTheme,
+  everforestTheme,
+  gruvboxTheme,
+  solarizedTheme,
+  scienceTheme,
+]

--- a/frontend/src/themes/nordTheme.ts
+++ b/frontend/src/themes/nordTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const nordTheme: ThemeDefinition = {
+  id: 'nord',
+  name: 'Nord',
+  palettes: {
+    light: {
+      canvas:       '#ECEFF4',
+      surface:      '#E5E9F0',
+      textInverse:  '#ECEFF4',
+      text:         '#2E3440',
+      textMuted:    '#4C566A',
+      border:       '#D8DEE9',
+      accent:       '#5E81AC',
+      accentHover:  '#4C6E96',
+      accentSubtle: '#D8E8F2',
+      positive:     '#A3BE8C',
+      negative:     '#BF616A',
+    },
+    dark: {
+      canvas:       '#2E3440',
+      surface:      '#3B4252',
+      textInverse:  '#2E3440',
+      text:         '#ECEFF4',
+      textMuted:    '#D8DEE9',
+      border:       '#4C566A',
+      accent:       '#88C0D0',
+      accentHover:  '#81A1C1',
+      accentSubtle: '#374060',
+      positive:     '#A3BE8C',
+      negative:     '#BF616A',
+    },
+  },
+}

--- a/frontend/src/themes/scienceTheme.ts
+++ b/frontend/src/themes/scienceTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const scienceTheme: ThemeDefinition = {
+  id: 'science',
+  name: 'Science',
+  palettes: {
+    light: {
+      canvas:       '#f1f8fd',
+      surface:      '#e6f1fc',
+      textInverse:  '#ffffff',
+      text:         '#2a3a46',
+      textMuted:    '#5c6b76',
+      border:       '#d6dde3',
+      accent:       '#3a8ed0',
+      accentHover:  '#1f5e91',
+      accentSubtle: '#ddeef9',
+      positive:     '#2f5a44',
+      negative:     '#8c4b2a',
+    },
+    dark: {
+      canvas:       '#0f1720',
+      surface:      '#1b2a36',
+      textInverse:  '#0f1720',
+      text:         '#d4dde4',
+      textMuted:    '#9fb0bd',
+      border:       '#2b3944',
+      accent:       '#4fa3e0',
+      accentHover:  '#3a8ed0',
+      accentSubtle: '#1c3347',
+      positive:     '#a7d0bb',
+      negative:     '#d07b57',
+    },
+  },
+}

--- a/frontend/src/themes/solarizedTheme.ts
+++ b/frontend/src/themes/solarizedTheme.ts
@@ -1,0 +1,34 @@
+import type { ThemeDefinition } from './types'
+
+export const solarizedTheme: ThemeDefinition = {
+  id: 'solarized',
+  name: 'Solarized',
+  palettes: {
+    light: {
+      canvas:       '#fdf6e3',
+      surface:      '#eee8d5',
+      textInverse:  '#fdf6e3',
+      text:         '#657b83',
+      textMuted:    '#586e75',
+      border:       '#93a1a1',
+      accent:       '#268bd2',
+      accentHover:  '#1f74b3',
+      accentSubtle: '#ddeef8',
+      positive:     '#859900',
+      negative:     '#dc322f',
+    },
+    dark: {
+      canvas:       '#002b36',
+      surface:      '#073642',
+      textInverse:  '#002b36',
+      text:         '#839496',
+      textMuted:    '#93a1a1',
+      border:       '#586e75',
+      accent:       '#268bd2',
+      accentHover:  '#1f74b3',
+      accentSubtle: '#0a3040',
+      positive:     '#859900',
+      negative:     '#dc322f',
+    },
+  },
+}

--- a/frontend/src/themes/themeManager.ts
+++ b/frontend/src/themes/themeManager.ts
@@ -1,0 +1,31 @@
+import type { ThemeDefinition, ThemeMode } from './types'
+
+const tokenToCssVarMap: Record<string, string[]> = {
+  canvas:       ['--color-canvas'],
+  surface:      ['--color-surface'],
+  textInverse:  ['--color-text-inverse'],
+  text:         ['--color-text'],
+  textMuted:    ['--color-text-muted'],
+  border:       ['--color-border'],
+  accent:       ['--color-accent'],
+  accentHover:  ['--color-accent-hover'],
+  accentSubtle: ['--color-accent-subtle'],
+  positive:     ['--color-positive'],
+  negative:     ['--color-negative'],
+}
+
+export function applyTheme(theme: ThemeDefinition, mode: ThemeMode) {
+  const root = document.documentElement
+  const palette = theme.palettes[mode]
+
+  root.setAttribute('data-theme', mode)
+  root.setAttribute('data-theme-id', theme.id)
+
+  for (const [token, value] of Object.entries(palette)) {
+    const cssVars = tokenToCssVarMap[token]
+    if (!cssVars) continue
+    for (const cssVar of cssVars) {
+      root.style.setProperty(cssVar, value)
+    }
+  }
+}

--- a/frontend/src/themes/types.ts
+++ b/frontend/src/themes/types.ts
@@ -1,0 +1,24 @@
+export type ThemeMode = 'light' | 'dark'
+
+export interface ThemePalette {
+  canvas: string
+  surface: string
+  textInverse: string
+  text: string
+  textMuted: string
+  border: string
+  accent: string
+  accentHover: string
+  accentSubtle: string
+  positive: string
+  negative: string
+}
+
+export interface ThemeDefinition {
+  id: string
+  name: string
+  palettes: {
+    light: ThemePalette
+    dark: ThemePalette
+  }
+}


### PR DESCRIPTION
## Summary
- Adds theme support and initial themes (nord, gruvbox, everforest, and more).

## Changes
- Added ThemeContext, ThemeSelector, ThemeToggle updates
- Added theme files and themeManager

## Validation
- [x] `cargo check --manifest-path backend/Cargo.toml`
- [x] `cargo clippy --manifest-path backend/Cargo.toml -- -D warnings`
- [x] `npm run build --prefix frontend`

## Notes
- [x] No breaking changes
