### PR TITLE
fix: correct math for variable bills when some bills are zero

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -28,7 +28,7 @@ fn average_variable_amounts(amounts: &[VariableAmount]) -> f64 {
         return 0.0;
     }
     let sum: f64 = amounts.iter().map(|a| a.amount).sum();
-    sum / amounts.len() as f64
+    sum / 12.0
 }
 
 fn get_item_tags(conn: &rusqlite::Connection, item_id: i64) -> Vec<String> {


### PR DESCRIPTION
## Summary
- Fixes math for variable bills when some bills are zero

## Changes
- Adjusted calculation logic in backend/src/handlers.rs

## Validation
- [x] `cargo check --manifest-path backend/Cargo.toml`
- [x] `cargo clippy --manifest-path backend/Cargo.toml -- -D warnings`
- [x] `npm run build --prefix frontend`

## Notes
- [x] No breaking changes