### PR TITLE
refactor: Budget item tag controls / UX improvements

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -100,6 +100,32 @@ fn build_budget_item(
     }
 }
 
+fn normalize_tag_order(tags: &Option<Vec<String>>) -> Option<Vec<String>> {
+    tags.as_ref().map(|tags| {
+        let mut ordered = Vec::new();
+        let mut seen = HashSet::new();
+
+        for tag in tags {
+            if seen.insert(tag.clone()) {
+                ordered.push(tag.clone());
+            }
+        }
+
+        if ordered.is_empty() {
+            ordered
+        } else {
+            let primary = ordered[0].clone();
+            let mut reordered = vec![primary.clone()];
+            for tag in ordered.into_iter().skip(1) {
+                if tag != primary {
+                    reordered.push(tag);
+                }
+            }
+            reordered
+        }
+    })
+}
+
 fn save_tags(conn: &rusqlite::Connection, item_id: i64, tags: &Option<Vec<String>>) {
     if let Some(ref tags) = tags {
         for tag_name in tags {
@@ -198,7 +224,8 @@ pub async fn create_budget_item(
     .map_err(|_| StatusCode::BAD_REQUEST)?;
 
     let id = db.last_insert_rowid();
-    save_tags(&db, id, &input.tags);
+    let normalized_tags = normalize_tag_order(&input.tags);
+    save_tags(&db, id, &normalized_tags);
     save_variable_amounts(&db, id, &input.variable_amounts);
 
     let created_at = db
@@ -292,7 +319,8 @@ pub async fn update_budget_item(
 
     db.execute("DELETE FROM budget_item_tags WHERE budget_item_id = ?1", [id])
         .ok();
-    save_tags(&db, id, &input.tags);
+    let normalized_tags = normalize_tag_order(&input.tags);
+    save_tags(&db, id, &normalized_tags);
 
     db.execute("DELETE FROM variable_amounts WHERE budget_item_id = ?1", [id])
         .ok();

--- a/frontend/src/components/BudgetItemForm.tsx
+++ b/frontend/src/components/BudgetItemForm.tsx
@@ -16,12 +16,14 @@ export default function BudgetItemForm({ item, onSave, onCancel }: Props) {
   const [itemType, setItemType] = useState<'income' | 'expense'>(item?.item_type ?? 'expense');
   const [frequency, setFrequency] = useState(item?.frequency ?? 'monthly');
   const [dayOfMonth, setDayOfMonth] = useState<number | ''>(item?.day_of_month ?? '');
-  // Add default 'Income' tag for salary/freelance if creating new income item
-  const defaultIncomeTags = ['salary', 'freelance', 'contract', 'consulting'];
-  const isNewIncome = !item && itemType === 'income';
-  const [selectedTags, setSelectedTags] = useState<string[]>(
-    item?.tags ?? (isNewIncome ? ['Income'] : [])
+
+  const initialTags = item?.tags ?? [];
+  const initialPrimaryTag = initialTags[0] ?? '';
+  const [primaryTag, setPrimaryTag] = useState<string>(initialPrimaryTag);
+  const [additionalTags, setAdditionalTags] = useState<string[]>(
+    initialTags.filter((t) => t !== initialPrimaryTag),
   );
+
   const [notes, setNotes] = useState(item?.notes ?? '');
   const [isVariable, setIsVariable] = useState(!!item?.variable_amounts?.length);
   const [variableAmounts, setVariableAmounts] = useState<number[]>(
@@ -40,17 +42,15 @@ export default function BudgetItemForm({ item, onSave, onCancel }: Props) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    let tagsToSave = selectedTags;
-    // If new income and no tags, add 'Income' tag by default
-    if (isNewIncome && tagsToSave.length === 0) {
-      tagsToSave = ['Income'];
+    if (!primaryTag) {
+      alert('Primary tag is required.');
+      return;
     }
-    // If new income and tag matches default income sources, add 'Income' tag
-    if (isNewIncome && !tagsToSave.includes('Income')) {
-      if (defaultIncomeTags.some((t) => name.toLowerCase().includes(t))) {
-        tagsToSave = [...tagsToSave, 'Income'];
-      }
-    }
+
+    let tagsToSave = [primaryTag];
+    tagsToSave.push(...additionalTags.filter((tag) => tag !== primaryTag));
+    tagsToSave = Array.from(new Set(tagsToSave));
+
     const data: CreateBudgetItem = {
       name,
       amount: isVariable ? 0 : amount,
@@ -73,42 +73,38 @@ export default function BudgetItemForm({ item, onSave, onCancel }: Props) {
     onSave();
   };
 
-  const toggleTag = (tagName: string) => {
-    setSelectedTags((prev) =>
-      prev.includes(tagName) ? prev.filter((t) => t !== tagName) : [...prev, tagName],
-    );
-  };
-
   return (
     <form className="budget-form" onSubmit={handleSubmit}>
       <h2>{item ? 'Edit Item' : 'New Budget Item'}</h2>
 
-      <div className="form-row">
-        <label>Name</label>
-        <input type="text" value={name} onChange={(e) => setName(e.target.value)} required />
-      </div>
+      <div className="form-row-inline">
+        <div style={{ flex: 1 }}>
+          <label>Name</label>
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
 
-      <div className="form-row">
-        <label>Type</label>
-        <div className="btn-group">
-          <button
-            type="button"
-            className={`btn ${itemType === 'income' ? 'active' : ''}`}
-            onClick={() => setItemType('income')}
-          >
-            Income
-          </button>
-          <button
-            type="button"
-            className={`btn ${itemType === 'expense' ? 'active' : ''}`}
-            onClick={() => setItemType('expense')}
-          >
-            Expense
-          </button>
+        <div style={{ minWidth: '170px' }}>
+          <label>Type</label>
+          <div className="btn-group">
+            <button
+              type="button"
+              className={`btn btn-income ${itemType === 'income' ? 'active' : ''}`}
+              onClick={() => setItemType('income')}
+            >
+              Income
+            </button>
+            <button
+              type="button"
+              className={`btn btn-expense ${itemType === 'expense' ? 'active' : ''}`}
+              onClick={() => setItemType('expense')}
+            >
+              Expense
+            </button>
+          </div>
         </div>
       </div>
 
-      <div className="form-row">
+      <div className="form-row variable-toggle">
         <label>
           <input
             type="checkbox"
@@ -151,45 +147,94 @@ export default function BudgetItemForm({ item, onSave, onCancel }: Props) {
               required
             />
           </div>
-          <div className="form-row">
-            <label>Frequency</label>
-            <select value={frequency} onChange={(e) => setFrequency(e.target.value as CreateBudgetItem['frequency'])}>
-              <option value="daily">Daily</option>
-              <option value="weekly">Weekly</option>
-              <option value="biweekly">Biweekly</option>
-              <option value="monthly">Monthly</option>
-              <option value="yearly">Yearly</option>
-            </select>
+
+          <div className="form-row-inline">
+            <div style={{ flex: 1 }}>
+              <label>Frequency</label>
+              <select
+                value={frequency}
+                onChange={(e) => setFrequency(e.target.value as CreateBudgetItem['frequency'])}
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="biweekly">Biweekly</option>
+                <option value="monthly">Monthly</option>
+                <option value="yearly">Yearly</option>
+              </select>
+            </div>
+
+            <div style={{ minWidth: '170px' }}>
+              <label>Day of Month (optional)</label>
+              <input
+                className="small-input"
+                type="number"
+                min="1"
+                max="31"
+                value={dayOfMonth}
+                onChange={(e) => setDayOfMonth(e.target.value === '' ? '' : parseInt(e.target.value))}
+              />
+            </div>
           </div>
         </>
       )}
 
       <div className="form-row">
-        <label>Day of Month (optional)</label>
-        <input
-          type="number"
-          min="1"
-          max="31"
-          value={dayOfMonth}
-          onChange={(e) =>
-            setDayOfMonth(e.target.value === '' ? '' : parseInt(e.target.value))
-          }
-        />
+        <label>
+          Primary Tag
+          <small className="helper-text">
+            Select the main tag for this item. This determines which category it appears under in the Sankey diagram and calculations.
+          </small>
+        </label>
+        <select
+          value={primaryTag}
+          onChange={(e) => {
+            const value = e.target.value;
+            setPrimaryTag(value);
+            setAdditionalTags((prev) => prev.filter((tag) => tag !== value));
+          }}
+          required
+        >
+          <option value="" disabled>
+            Select primary tag
+          </option>
+          {availableTags.map((tag) => (
+            <option key={tag.id} value={tag.name}>
+              {tag.name}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className="form-row">
-        <label>Tags</label>
+        <label>
+          Additional Tags
+          <small className="helper-text">
+            Select any additional tags to help filter and organize items in the summary view. These do not affect the Sankey diagram.
+          </small>
+        </label>
         <div className="tag-selector">
-          {availableTags.map((tag) => (
-            <button
-              key={tag.id}
-              type="button"
-              className={`tag-badge ${selectedTags.includes(tag.name) ? 'selected' : ''}`}
-              onClick={() => toggleTag(tag.name)}
-            >
-              {tag.name}
-            </button>
-          ))}
+          {availableTags
+            .filter((tag) => tag.name !== primaryTag)
+            .map((tag) => {
+              const active = additionalTags.includes(tag.name);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  className={`tag-badge ${active ? 'selected' : ''}`}
+                  onClick={() => {
+                    setAdditionalTags((prev) => {
+                      if (prev.includes(tag.name)) {
+                        return prev.filter((t) => t !== tag.name);
+                      }
+                      return [...prev, tag.name];
+                    });
+                  }}
+                >
+                  {tag.name}
+                </button>
+              );
+            })}
         </div>
       </div>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -58,6 +58,7 @@
   --space-6:  24px;
   --space-8:  32px;
   --space-12: 48px;
+  --space-16: 64px;
 
   /* Typography */
   --font-xs:   0.8rem;
@@ -552,12 +553,17 @@ body {
   background: var(--color-surface);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: var(--space-6);
+  padding: var(--space-4) var(--space-6) var(--space-6);
   margin-bottom: var(--space-6);
 }
 
 .budget-form h2 {
   margin-bottom: var(--space-5);
+}
+
+.form-row.variable-toggle {
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-4);
 }
 
 .form-row {
@@ -572,11 +578,36 @@ body {
   color: var(--color-text-muted);
 }
 
+.form-row label .helper-text {
+  display: block;
+  margin-top: var(--space-1);
+  font-weight: 400;
+  font-size: var(--font-xs);
+  color: var(--color-text-muted);
+  white-space: normal;
+}
+
+.form-row-inline {
+  align-items: flex-start;
+}
+
+.form-row-inline > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.small-input {
+  width: 100%;
+  max-width: 100%;
+}
+
 .form-row input[type='text'],
 .form-row input[type='number'],
 .form-row select,
-.form-row textarea {
+.form-row textarea,
+.form-row-inline select {
   width: 100%;
+  min-height: 44px;
   padding: var(--space-3) var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -585,6 +616,19 @@ body {
   font-family: inherit;
   font-size: var(--font-base);
   transition: border-color var(--transition);
+}
+
+.form-row-inline .btn-group .btn {
+  width: auto;
+  min-width: 80px;
+  min-height: 44px;
+  padding: var(--space-3) var(--space-4);
+  line-height: 1;
+}
+
+.form-row label,
+.form-row-inline label {
+  white-space: nowrap;
 }
 
 .form-row input[type='checkbox'] {
@@ -603,6 +647,7 @@ body {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  margin-bottom: var(--space-4);
 }
 
 .form-row-inline label {
@@ -615,13 +660,14 @@ body {
 .form-row-inline input {
   flex: 1;
   min-width: 0;
-  padding: var(--space-2) var(--space-3);
+  min-height: 44px;
+  padding: var(--space-3) var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-canvas);
   color: var(--color-text);
   font-family: inherit;
-  font-size: var(--font-sm);
+  font-size: var(--font-base);
 }
 
 .form-row-inline input[type='number'] {
@@ -989,6 +1035,22 @@ body {
 
   .theme-selector-label {
     display: none;
+  }
+
+  /* Budget item edit/create layout: stack fields on mobile for readability */
+  .form-row-inline {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-3);
+  }
+
+  .form-row-inline > div {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .form-row-inline label {
+    min-width: 0;
   }
 
 }


### PR DESCRIPTION
## Summary
Refactor budget item entry form to support users selecting a primary tag plus optional additional tags. Secondary tags do not affect Sankey calculation, and are used for filtering in the summary form.

## Details
- Backend: enforce canonical tag order (primary first) in create/update path via normalize_tag_order and schema save.
- Frontend: new UI in BudgetItemForm.tsx for primary tag select + additional tag pills.
- Layout: inline rows for name/type and frequency/day-of-month, mobile stack, improved spacing and helper text wrapping.

## Validation
- cargo check --manifest-path backend/Cargo.toml ✓
- cargo clippy --manifest-path backend/Cargo.toml -- -D warnings ✓
- npm run build --prefix frontend ✓

Closes #20