### PR TITLE
feat: allow users to click a tag in the item list to set it as primary (controls Sankey diagram appearance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Open `http://localhost:3001`. Data persists to `./data/budget.db`.
 | DELETE | /api/tags/:id | Delete a tag |
 | GET | /api/cashflow | Get Sankey diagram data |
 | GET | /api/upcoming-bills | Get upcoming bills |
+| PATCH | /api/budget-items/:id/primary-tag | Set a budget item primary tag (adds to tags if needed) |
 
 ## Normalization
 

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -3,6 +3,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use rusqlite::OptionalExtension;
 use std::collections::{HashMap, HashSet};
 
 use crate::db::Db;
@@ -348,6 +349,86 @@ pub async fn update_budget_item(
         input.day_of_month,
         input.notes,
         input.primary_tag,
+        created_at,
+    )))
+}
+
+pub async fn update_budget_item_primary_tag(
+    State(db): State<Db>,
+    Path(id): Path<i64>,
+    Json(input): Json<UpdatePrimaryTag>,
+) -> Result<Json<BudgetItem>, StatusCode> {
+    let db = db.lock().await;
+
+    let primary_tag = input.primary_tag.trim();
+    if primary_tag.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let exists = db
+        .query_row(
+            "SELECT 1 FROM budget_items WHERE id = ?1",
+            [id],
+            |_row| Ok(1),
+        )
+        .optional()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .is_some();
+
+    if !exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Ensure primary_tag exists in tags and association exists
+    db.execute("INSERT OR IGNORE INTO tags (name) VALUES (?1)", [primary_tag])
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let tag_id: i64 = db
+        .query_row("SELECT id FROM tags WHERE name = ?1", [primary_tag], |row| row.get(0))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    db.execute(
+        "INSERT OR IGNORE INTO budget_item_tags (budget_item_id, tag_id) VALUES (?1, ?2)",
+        rusqlite::params![id, tag_id],
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    db.execute(
+        "UPDATE budget_items SET primary_tag = ?1 WHERE id = ?2",
+        rusqlite::params![primary_tag, id],
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag_val, created_at): BudgetItemRow =
+        db.query_row(
+            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at FROM budget_items WHERE id = ?1",
+            [id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, f64>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, Option<i32>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, String>(8)?,
+                ))
+            },
+        )
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    Ok(Json(build_budget_item(
+        &db,
+        id,
+        name,
+        amount,
+        item_type,
+        frequency,
+        day_of_month,
+        notes,
+        primary_tag_val,
         created_at,
     )))
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -32,6 +32,10 @@ async fn main() {
                 .delete(handlers::delete_budget_item),
         )
         .route(
+            "/api/budget-items/:id/primary-tag",
+            axum::routing::patch(handlers::update_budget_item_primary_tag),
+        )
+        .route(
             "/api/tags",
             get(handlers::list_tags).post(handlers::create_tag),
         )

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -30,6 +30,11 @@ pub struct CreateBudgetItem {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdatePrimaryTag {
+    pub primary_tag: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VariableAmount {
     pub month: i32,
     pub amount: f64,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,6 +29,15 @@ export async function deleteBudgetItem(id: number): Promise<void> {
   await fetch(`${API}/budget-items/${id}`, { method: 'DELETE' });
 }
 
+export async function updateBudgetItemPrimaryTag(id: number, primary_tag: string): Promise<BudgetItem> {
+  const res = await fetch(`${API}/budget-items/${id}/primary-tag`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ primary_tag }),
+  });
+  return res.json();
+}
+
 export async function fetchTags(): Promise<Tag[]> {
   const res = await fetch(`${API}/tags`);
   return res.json();

--- a/frontend/src/pages/BudgetItems.tsx
+++ b/frontend/src/pages/BudgetItems.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { fetchBudgetItems, deleteBudgetItem } from '../api';
+import { fetchBudgetItems, deleteBudgetItem, updateBudgetItemPrimaryTag } from '../api';
 import type { BudgetItem } from '../types';
 import BudgetItemForm from '../components/BudgetItemForm';
 import { PlusIcon, TrashIcon, PencilSimpleIcon } from '@phosphor-icons/react';
@@ -82,11 +82,25 @@ export default function BudgetItems() {
             </div>
             {item.tags.length > 0 && (
               <div className="item-tags">
-                {item.tags.map((tag, index) => (
-                  <span key={`${item.id}-${tag}`} className={`tag-badge ${tag === item.primary_tag ? 'selected' : ''}`}>
-                    {tag}
-                  </span>
-                ))}
+                {item.tags.map((tag) => {
+                  const isPrimary = tag === item.primary_tag;
+                  return (
+                    <button
+                      key={`${item.id}-${tag}`}
+                      type="button"
+                      className={`tag-badge ${isPrimary ? 'selected' : ''}`}
+                      onClick={async () => {
+                        if (!isPrimary && item.tags.length > 1) {
+                          await updateBudgetItemPrimaryTag(item.id, tag);
+                          load();
+                        }
+                      }}
+                      title={isPrimary ? 'Primary tag' : 'Click to make primary'}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
               </div>
             )}
             {item.notes && <p className="item-notes">{item.notes}</p>}


### PR DESCRIPTION
## Summary

This feature allows users to click on a tag in the item list to set it as the primary tag, which determines how the item appears in the Sankey diagram.

## Changes

- Users can now click a tag in the item list to set it as primary
- Updates backend and frontend to support this interaction
- Updates README with usage instructions

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes