### PR TITLE
feat: add snapshot/archive support for budget state (create/list/activate/reset/delete/rename, frontend UI, active DB warning)

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,27 +1,59 @@
 use rusqlite::Connection;
-use std::sync::Arc;
+use std::{fs, path::{Path, PathBuf}, sync::Arc};
 use tokio::sync::Mutex;
 
-pub type Db = Arc<Mutex<Connection>>;
+pub const DEFAULT_DB_PATH: &str = "data/budget.db";
+pub const SNAPSHOT_DIR: &str = "data/snapshots";
 
-pub fn init_db(path: &str) -> Db {
-    let conn = Connection::open(path).expect("Failed to open database");
-    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-        .expect("Failed to set pragmas");
+pub struct DbState {
+    active_db_path: Mutex<PathBuf>,
+    default_db_path: PathBuf,
+}
 
+pub type Db = Arc<DbState>;
+
+impl DbState {
+    pub async fn active_db_path(&self) -> PathBuf {
+        self.active_db_path.lock().await.clone()
+    }
+
+    pub async fn set_active_db_path(&self, path: PathBuf) {
+        let mut current = self.active_db_path.lock().await;
+        *current = path;
+    }
+
+    pub async fn reset_active_db_path(&self) {
+        let mut current = self.active_db_path.lock().await;
+        *current = self.default_db_path.clone();
+    }
+
+    pub async fn is_default_path(&self) -> bool {
+        let current = self.active_db_path.lock().await;
+        *current == self.default_db_path
+    }
+
+    pub async fn get_connection(&self) -> rusqlite::Result<Connection> {
+        let path = self.active_db_path().await;
+        let conn = Connection::open(path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        Ok(conn)
+    }
+}
+
+fn initialize_schema(conn: &Connection) {
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;").expect("Failed to set pragmas");
     let schema = include_str!("schema.sql");
     conn.execute_batch(schema).expect("Failed to initialize schema");
-
-    // Migrations for existing databases
     conn.execute_batch(
-        "ALTER TABLE budget_item_tags ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0"
-    ).ok();
+        "ALTER TABLE budget_item_tags ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
+    )
+    .ok();
     conn.execute_batch(
-        "ALTER TABLE budget_items ADD COLUMN primary_tag TEXT NOT NULL DEFAULT 'Uncategorized'"
-    ).ok();
-    // 1) Set primary_tag when exactly one tag exists for the item.
-    conn.execute_batch("
-        UPDATE budget_items
+        "ALTER TABLE budget_items ADD COLUMN primary_tag TEXT NOT NULL DEFAULT 'Uncategorized'",
+    )
+    .ok();
+    conn.execute_batch(
+        "UPDATE budget_items
         SET primary_tag = (
             SELECT t.name FROM tags t
             JOIN budget_item_tags bt ON t.id = bt.tag_id
@@ -31,12 +63,11 @@ pub fn init_db(path: &str) -> Db {
         WHERE (primary_tag IS NULL OR primary_tag = '' OR primary_tag = 'Uncategorized')
         AND (
             SELECT COUNT(*) FROM budget_item_tags WHERE budget_item_id = budget_items.id
-        ) = 1
-    ").ok();
-
-    // 2) Set primary_tag from first tag (by tag_id) for items with multiple tags.
-    conn.execute_batch("
-        UPDATE budget_items
+        ) = 1",
+    )
+    .ok();
+    conn.execute_batch(
+        "UPDATE budget_items
         SET primary_tag = (
             SELECT t.name FROM tags t
             JOIN budget_item_tags bt ON t.id = bt.tag_id
@@ -46,11 +77,34 @@ pub fn init_db(path: &str) -> Db {
         WHERE (primary_tag IS NULL OR primary_tag = '' OR primary_tag = 'Uncategorized')
         AND (
             SELECT COUNT(*) FROM budget_item_tags WHERE budget_item_id = budget_items.id
-        ) > 1
-    ").ok();
-
-    // 3) Set Uncategorized for no tags.
-    conn.execute_batch("UPDATE budget_items SET primary_tag = 'Uncategorized' WHERE primary_tag IS NULL OR primary_tag = '' OR primary_tag = 'Uncategorized'").ok();
-
-    Arc::new(Mutex::new(conn))
+        ) > 1",
+    )
+    .ok();
+    conn.execute_batch(
+        "UPDATE budget_items SET primary_tag = 'Uncategorized' WHERE primary_tag IS NULL OR primary_tag = '' OR primary_tag = 'Uncategorized'",
+    )
+    .ok();
 }
+
+pub fn init_db(path: Option<&str>) -> Db {
+    let db_path = path.unwrap_or(DEFAULT_DB_PATH);
+    let db_dir = Path::new(db_path).parent().unwrap_or_else(|| Path::new("data"));
+    fs::create_dir_all(db_dir).expect("Failed to create data directory");
+    fs::create_dir_all(SNAPSHOT_DIR).expect("Failed to create snapshots directory");
+
+    if !Path::new(db_path).exists() {
+        let conn = Connection::open(db_path).expect("Failed to open database");
+        initialize_schema(&conn);
+    } else {
+        let conn = Connection::open(db_path).expect("Failed to open database");
+        initialize_schema(&conn);
+    }
+
+    let default_db_path = fs::canonicalize(db_path).unwrap_or_else(|_| PathBuf::from(db_path));
+
+    Arc::new(DbState {
+        active_db_path: Mutex::new(default_db_path.clone()),
+        default_db_path,
+    })
+}
+

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     Json,
 };
 use rusqlite::OptionalExtension;
-use std::collections::{HashMap, HashSet};
+use std::{collections::{HashMap, HashSet}, fs, path::PathBuf, time::{SystemTime, UNIX_EPOCH}};
 
 use crate::db::Db;
 use crate::models::*;
@@ -145,8 +145,14 @@ fn save_variable_amounts(
 
 // --- Budget Items ---
 
+async fn get_db_conn(db: &Db) -> Result<rusqlite::Connection, StatusCode> {
+    db.get_connection()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
 pub async fn list_budget_items(State(db): State<Db>) -> Result<Json<Vec<BudgetItem>>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let mut stmt = db
         .prepare(
@@ -189,7 +195,7 @@ pub async fn create_budget_item(
     State(db): State<Db>,
     Json(input): Json<CreateBudgetItem>,
 ) -> Result<(StatusCode, Json<BudgetItem>), StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     if input.primary_tag.trim().is_empty() {
         return Err(StatusCode::BAD_REQUEST);
@@ -248,7 +254,7 @@ pub async fn get_budget_item(
     State(db): State<Db>,
     Path(id): Path<i64>,
 ) -> Result<Json<BudgetItem>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at): BudgetItemRow =
         db.query_row(
@@ -290,7 +296,7 @@ pub async fn update_budget_item(
     Path(id): Path<i64>,
     Json(input): Json<CreateBudgetItem>,
 ) -> Result<Json<BudgetItem>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let changes = db
         .execute(
@@ -358,7 +364,7 @@ pub async fn update_budget_item_primary_tag(
     Path(id): Path<i64>,
     Json(input): Json<UpdatePrimaryTag>,
 ) -> Result<Json<BudgetItem>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let primary_tag = input.primary_tag.trim();
     if primary_tag.is_empty() {
@@ -437,7 +443,10 @@ pub async fn delete_budget_item(
     State(db): State<Db>,
     Path(id): Path<i64>,
 ) -> StatusCode {
-    let db = db.lock().await;
+    let db = match get_db_conn(&db).await {
+        Ok(conn) => conn,
+        Err(status) => return status,
+    };
     match db.execute("DELETE FROM budget_items WHERE id = ?1", [id]) {
         Ok(changes) if changes > 0 => StatusCode::NO_CONTENT,
         _ => StatusCode::NOT_FOUND,
@@ -447,7 +456,7 @@ pub async fn delete_budget_item(
 // --- Tags ---
 
 pub async fn list_tags(State(db): State<Db>) -> Result<Json<Vec<Tag>>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
     let mut stmt = db
         .prepare("SELECT id, name FROM tags ORDER BY name")
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -467,7 +476,7 @@ pub async fn create_tag(
     State(db): State<Db>,
     Json(input): Json<CreateTag>,
 ) -> Result<(StatusCode, Json<Tag>), StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
     db.execute("INSERT INTO tags (name) VALUES (?1)", [&input.name])
         .map_err(|_| StatusCode::CONFLICT)?;
     let id = db.last_insert_rowid();
@@ -479,7 +488,7 @@ pub async fn rename_tag(
     Path(id): Path<i64>,
     Json(input): Json<RenameTag>,
 ) -> Result<Json<Tag>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
     let changes = db
         .execute(
             "UPDATE tags SET name = ?1 WHERE id = ?2",
@@ -493,17 +502,231 @@ pub async fn rename_tag(
 }
 
 pub async fn delete_tag(State(db): State<Db>, Path(id): Path<i64>) -> StatusCode {
-    let db = db.lock().await;
+    let db = match get_db_conn(&db).await {
+        Ok(conn) => conn,
+        Err(status) => return status,
+    };
     match db.execute("DELETE FROM tags WHERE id = ?1", [id]) {
         Ok(changes) if changes > 0 => StatusCode::NO_CONTENT,
         _ => StatusCode::NOT_FOUND,
     }
 }
 
+pub async fn create_snapshot(
+    State(db): State<Db>,
+    Json(input): Json<CreateSnapshot>,
+) -> Result<Json<SnapshotInfo>, StatusCode> {
+    let active_path = db.active_db_path().await;
+    let label = input
+        .label
+        .as_ref()
+        .map(|l| l.trim().replace(' ', "-").chars().filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_').collect::<String>())
+        .filter(|l| !l.is_empty());
+
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?.as_secs();
+    let file_name = if let Some(label) = &label {
+        format!("{}-{}.db", timestamp, label)
+    } else {
+        format!("{}.db", timestamp)
+    };
+    let snapshot_dir = PathBuf::from(crate::db::SNAPSHOT_DIR);
+    let target = snapshot_dir.join(&file_name);
+
+    fs::create_dir_all(&snapshot_dir).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    fs::copy(&active_path, &target).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let created_at = target
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|| timestamp.to_string());
+
+    Ok(Json(SnapshotInfo {
+        filename: file_name,
+        created_at,
+        label,
+    }))
+}
+
+pub async fn list_snapshots(State(_): State<Db>) -> Result<Json<Vec<SnapshotInfo>>, StatusCode> {
+    let mut entries = fs::read_dir(crate::db::SNAPSHOT_DIR)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("db"))
+        .collect::<Vec<_>>();
+
+    entries.sort_by_key(|e| e.path());
+
+    let snapshots = entries
+        .into_iter()
+        .filter_map(|e| {
+            let path = e.path();
+            let filename = path.file_name()?.to_string_lossy().to_string();
+            let created_at = path
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs().to_string())
+                .unwrap_or_else(|| "0".to_string());
+            let label = filename
+                .strip_suffix(".db")
+                .and_then(|stem| stem.splitn(2, '-').nth(1))
+                .map(|s| s.to_string());
+            Some(SnapshotInfo {
+                filename,
+                created_at,
+                label,
+            })
+        })
+        .collect();
+
+    Ok(Json(snapshots))
+}
+
+pub async fn activate_snapshot(
+    State(db): State<Db>,
+    Json(input): Json<ActivateSnapshot>,
+) -> Result<Json<ActiveSnapshot>, StatusCode> {
+    if input.filename.contains('/') || input.filename.contains('\\') {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let candidate = PathBuf::from(crate::db::SNAPSHOT_DIR).join(&input.filename);
+    if !candidate.exists() || !candidate.is_file() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    db.set_active_db_path(candidate).await;
+
+    Ok(Json(ActiveSnapshot {
+        filename: Some(input.filename),
+        label: None,
+        created_at: None,
+    }))
+}
+
+pub async fn reset_snapshot(State(db): State<Db>) -> Result<Json<ActiveSnapshot>, StatusCode> {
+    db.reset_active_db_path().await;
+    Ok(Json(ActiveSnapshot {
+        filename: None,
+        label: None,
+        created_at: None,
+    }))
+}
+
+fn snapshot_path(filename: &str) -> Option<PathBuf> {
+    if filename.contains('/') || filename.contains('\\') {
+        return None;
+    }
+    let path = PathBuf::from(crate::db::SNAPSHOT_DIR).join(filename);
+    Some(path)
+}
+
+pub async fn delete_snapshot(State(db): State<Db>, Path(filename): Path<String>) -> StatusCode {
+    let path = match snapshot_path(&filename) {
+        Some(p) => p,
+        None => return StatusCode::BAD_REQUEST,
+    };
+
+    if !path.exists() || !path.is_file() {
+        return StatusCode::NOT_FOUND;
+    }
+
+    let active_filename = db.active_db_path().await.file_name().and_then(|s| s.to_str()).map(|s| s.to_string());
+    if let Err(_) = std::fs::remove_file(&path) {
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    }
+
+    if active_filename.as_deref() == Some(&filename) {
+        db.reset_active_db_path().await;
+    }
+
+    StatusCode::NO_CONTENT
+}
+
+pub async fn rename_snapshot(
+    State(_db): State<Db>,
+    Path(filename): Path<String>,
+    Json(input): Json<RenameSnapshot>,
+) -> Result<Json<SnapshotInfo>, StatusCode> {
+    let src = snapshot_path(&filename).ok_or(StatusCode::BAD_REQUEST)?;
+    if !src.exists() || !src.is_file() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let timestamp = filename
+        .strip_suffix(".db")
+        .and_then(|s| s.splitn(2, '-').next())
+        .unwrap_or("");
+
+    let label = input.label.trim();
+    let sanitized = label
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect::<String>();
+
+    let newname = if sanitized.is_empty() {
+        format!("{}.db", timestamp)
+    } else {
+        format!("{}-{}.db", timestamp, sanitized)
+    };
+
+    let dst = snapshot_path(&newname).ok_or(StatusCode::BAD_REQUEST)?;
+    if dst.exists() {
+        return Err(StatusCode::CONFLICT);
+    }
+
+    std::fs::rename(&src, &dst).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let created_at = dst
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|| "0".to_string());
+
+    Ok(Json(SnapshotInfo {
+        filename: newname,
+        created_at,
+        label: if sanitized.is_empty() { None } else { Some(sanitized) },
+    }))
+}
+
+pub async fn get_active_snapshot(State(db): State<Db>) -> Result<Json<ActiveSnapshot>, StatusCode> {
+    if db.is_default_path().await {
+        Ok(Json(ActiveSnapshot { filename: None, label: None, created_at: None }))
+    } else {
+        let active = db.active_db_path().await;
+        let filename = active.file_name().and_then(|s| s.to_str()).map(|s| s.to_string());
+        let label = filename
+            .as_ref()
+            .and_then(|name| name.strip_suffix(".db"))
+            .and_then(|stem| stem.splitn(2, '-').nth(1))
+            .map(|s| s.to_string());
+
+        let created_at = active
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs().to_string());
+
+        Ok(Json(ActiveSnapshot {
+            filename,
+            label,
+            created_at,
+        }))
+    }
+}
+
 // --- Cashflow (Sankey Data) ---
 
 pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let mut stmt = db
         .prepare("SELECT id, name, amount, item_type, frequency, primary_tag FROM budget_items")
@@ -606,7 +829,7 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
 // --- Upcoming Bills ---
 
 pub async fn get_upcoming_bills(State(db): State<Db>) -> Result<Json<Vec<UpcomingBill>>, StatusCode> {
-    let db = db.lock().await;
+    let db = get_db_conn(&db).await?;
 
     let mut stmt = db
         .prepare(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
         std::fs::create_dir_all(dir).expect("Failed to create data directory");
         "data/budget.db".to_string()
     });
-    let db = db::init_db(&db_path);
+    let db = db::init_db(Some(&db_path));
 
     let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_| "../frontend/dist".to_string());
 
@@ -45,6 +45,11 @@ async fn main() {
         )
         .route("/api/cashflow", get(handlers::get_cashflow))
         .route("/api/upcoming-bills", get(handlers::get_upcoming_bills))
+        .route("/api/snapshots", get(handlers::list_snapshots).post(handlers::create_snapshot))
+        .route("/api/snapshots/:filename", axum::routing::delete(handlers::delete_snapshot).put(handlers::rename_snapshot))
+        .route("/api/snapshots/activate", axum::routing::post(handlers::activate_snapshot))
+        .route("/api/snapshots/reset", axum::routing::post(handlers::reset_snapshot))
+        .route("/api/snapshots/active", get(handlers::get_active_snapshot))
         .with_state(db)
         .fallback_service(
             ServeDir::new(&static_dir)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -57,6 +57,35 @@ pub struct RenameTag {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct CreateSnapshot {
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActivateSnapshot {
+    pub filename: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RenameSnapshot {
+    pub label: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotInfo {
+    pub filename: String,
+    pub created_at: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActiveSnapshot {
+    pub filename: Option<String>,
+    pub label: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SankeyData {
     pub nodes: Vec<SankeyNode>,
     pub links: Vec<SankeyLink>,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,34 @@
+import { useEffect, useState } from 'react'
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
-import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon } from '@phosphor-icons/react'
+import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon, BoxArrowDownIcon, WarningCircle } from '@phosphor-icons/react'
 import Dashboard from './pages/Dashboard'
 import BudgetItems from './pages/BudgetItems'
 import Summary from './pages/Summary'
 import Tags from './pages/Tags'
+import Snapshots from './pages/Snapshots'
 import ThemeToggle from './components/ThemeToggle'
 import ThemeSelector from './components/ThemeSelector'
 import { ThemeProvider } from './context/ThemeContext'
+import { fetchActiveSnapshot } from './api'
+import type { ActiveSnapshot } from './types'
 
 export default function App() {
+  const [activeSnapshot, setActiveSnapshot] = useState<ActiveSnapshot | null>(null)
+
+  useEffect(() => {
+    fetchActiveSnapshot()
+      .then((data) => setActiveSnapshot(data.filename ? data : null))
+      .catch(() => setActiveSnapshot(null))
+  }, [])
+
+  const activeSnapshotTitle = activeSnapshot
+    ? activeSnapshot.label
+      ? activeSnapshot.label
+      : activeSnapshot.created_at
+      ? new Date(Number(activeSnapshot.created_at) * 1000).toLocaleString()
+      : activeSnapshot.filename
+    : null
+
   return (
     <ThemeProvider>
       <BrowserRouter>
@@ -18,6 +38,11 @@ export default function App() {
               <img src="/icon-192.png" alt="" aria-hidden="true" />
               <span>Budget Overview</span>
             </div>
+            {activeSnapshot && activeSnapshotTitle && (
+              <div className="snapshot-warning-badge" role="status" aria-live="polite">
+                <WarningCircle size={16} /> <span>Snapshot active: {activeSnapshotTitle}</span>
+              </div>
+            )}
             <div className="nav-links">
               <NavLink to="/" end>
                 <HouseIcon size={20} /> <span>Dashboard</span>
@@ -31,6 +56,9 @@ export default function App() {
               <NavLink to="/tags">
                 <TagIcon size={20} /> <span>Tags</span>
               </NavLink>
+              <NavLink to="/snapshots">
+                <BoxArrowDownIcon size={20} /> <span>Snapshots</span>
+              </NavLink>
             </div>
             <ThemeSelector />
             <ThemeToggle />
@@ -41,6 +69,7 @@ export default function App() {
               <Route path="/items" element={<BudgetItems />} />
               <Route path="/summary" element={<Summary />} />
               <Route path="/tags" element={<Tags />} />
+              <Route path="/snapshots" element={<Snapshots />} />
             </Routes>
           </main>
         </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { BudgetItem, CreateBudgetItem, Tag, SankeyData, UpcomingBill } from './types';
+import type { BudgetItem, CreateBudgetItem, Tag, SankeyData, UpcomingBill, SnapshotInfo, ActiveSnapshot } from './types';
 
 const API = '/api';
 
@@ -74,3 +74,54 @@ export async function fetchUpcomingBills(): Promise<UpcomingBill[]> {
   const res = await fetch(`${API}/upcoming-bills`);
   return res.json();
 }
+
+export async function fetchSnapshots(): Promise<SnapshotInfo[]> {
+  const res = await fetch(`${API}/snapshots`);
+  return res.json();
+}
+
+export async function createSnapshot(label?: string): Promise<SnapshotInfo> {
+  const res = await fetch(`${API}/snapshots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ label }),
+  });
+  return res.json();
+}
+
+export async function activateSnapshot(filename: string): Promise<ActiveSnapshot> {
+  const res = await fetch(`${API}/snapshots/activate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ filename }),
+  });
+  return res.json();
+}
+
+export async function resetSnapshot(): Promise<ActiveSnapshot> {
+  const res = await fetch(`${API}/snapshots/reset`, {
+    method: 'POST',
+  });
+  return res.json();
+}
+
+export async function fetchActiveSnapshot(): Promise<ActiveSnapshot> {
+  const res = await fetch(`${API}/snapshots/active`);
+  return res.json();
+}
+
+export async function deleteSnapshot(filename: string): Promise<void> {
+  await fetch(`${API}/snapshots/${encodeURIComponent(filename)}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function renameSnapshot(filename: string, label: string): Promise<SnapshotInfo> {
+  const res = await fetch(`${API}/snapshots/${encodeURIComponent(filename)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ label }),
+  });
+  return res.json();
+}
+

--- a/frontend/src/pages/Snapshots.tsx
+++ b/frontend/src/pages/Snapshots.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react';
+import { ArchiveIcon, PencilSimpleIcon, PlusIcon, TrashIcon, CheckIcon, XIcon } from '@phosphor-icons/react';
+import { createSnapshot, fetchActiveSnapshot, fetchSnapshots, activateSnapshot, resetSnapshot, deleteSnapshot, renameSnapshot } from '../api';
+import type { SnapshotInfo, ActiveSnapshot } from '../types';
+
+export default function Snapshots() {
+  const [snapshots, setSnapshots] = useState<SnapshotInfo[]>([]);
+  const [active, setActive] = useState<ActiveSnapshot>({});
+  const [label, setLabel] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [editingFilename, setEditingFilename] = useState<string | null>(null);
+  const [editingLabel, setEditingLabel] = useState('');
+
+  const loadData = async () => {
+    setIsLoading(true);
+    try {
+      const [list, activeItem] = await Promise.all([fetchSnapshots(), fetchActiveSnapshot()]);
+      setSnapshots(list);
+      setActive(activeItem);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const handleCreateSnapshot = async () => {
+    await createSnapshot(label.trim() || undefined);
+    setLabel('');
+    await loadData();
+  };
+
+  const handleActivate = async (filename: string) => {
+    await activateSnapshot(filename);
+    await loadData();
+    window.location.reload();
+  };
+
+  const handleReset = async () => {
+    await resetSnapshot();
+    await loadData();
+    window.location.reload();
+  };
+
+  const handleDeleteSnapshot = async (filename: string) => {
+    await deleteSnapshot(filename);
+    await handleReset();
+  };
+
+  const handleRenameSnapshot = async () => {
+    if (!editingFilename) return;
+    const trimmedLabel = editingLabel.trim();
+    await renameSnapshot(editingFilename, trimmedLabel);
+    setEditingFilename(null);
+    setEditingLabel('');
+    await loadData();
+    window.location.reload();
+  };
+
+  const activeLabel = active.label || (active.created_at ? new Date(Number(active.created_at) * 1000).toLocaleString() : active.filename);
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <h1>Snapshots</h1>
+      </div>
+      <p className="snapshot-helper-text">Create a snapshot to save your current values before changing or updating them for a new year. This lets you easily revisit previous bills.</p>
+      <form className="tag-create-form" onSubmit={(e) => { e.preventDefault(); handleCreateSnapshot(); }}>
+        <input
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Optional snapshot label"
+        />
+        <button type="submit" className="btn btn-primary" disabled={isLoading}>
+          <PlusIcon size={16} /> Add
+        </button>
+      </form>
+
+      <p className="summary-value">
+        Viewing: <strong>{active.filename ? activeLabel : 'Current'}</strong>
+      </p>
+
+      <div className="summary-cards" style={{ gap: '8px', marginTop: '12px' }}>
+
+        <div className={`summary-card ${!active.filename ? 'active' : ''}`}>
+          <h3>Current database</h3>
+          <p>The active database</p>
+          <button className="btn btn-primary" onClick={handleReset} disabled={isLoading || !active.filename}>
+            Return to Current
+          </button>
+        </div>
+
+        {snapshots.length === 0 && <div className="empty-state">No snapshots yet.</div>}
+
+        {snapshots.map((snapshot) => {
+          const snapshotLabel = snapshot.label || snapshot.filename;
+          const isActive = active.filename === snapshot.filename;
+          const isEditing = editingFilename === snapshot.filename;
+          return (
+            <div key={snapshot.filename} className={`summary-card ${isActive ? 'active' : ''}`}>
+              {isEditing ? (
+                <div className="input-with-icon">
+                  <PencilSimpleIcon size={16} />
+                  <input
+                    value={editingLabel}
+                    onChange={(e) => setEditingLabel(e.target.value)}
+                    placeholder="Snapshot label"
+                    className="page-header-search"
+                  />
+                </div>
+              ) : (
+                <>
+                  <h3>{snapshotLabel}</h3>
+                  <p>{snapshot.created_at ? new Date(Number(snapshot.created_at) * 1000).toLocaleString() : 'Unknown'}</p>
+                </>
+              )}
+
+              <div className="snapshot-footer-row">
+                <button
+                  className="btn btn-primary snapshot-activate-btn"
+                  onClick={() => handleActivate(snapshot.filename)}
+                  disabled={isLoading || isActive || isEditing}
+                >
+                  Activate
+                </button>
+                <div className="snapshot-footer-icons">
+                {isEditing ? (
+                  <>
+                    <button className="btn-icon" onClick={handleRenameSnapshot}>
+                      <CheckIcon size={18} />
+                    </button>
+                    <button
+                      className="btn-icon"
+                      onClick={() => {
+                        setEditingFilename(null);
+                        setEditingLabel('');
+                      }}
+                    >
+                      <XIcon size={18} />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      className="btn-icon"
+                      onClick={() => {
+                        setEditingFilename(snapshot.filename);
+                        setEditingLabel(snapshot.label || '');
+                      }}
+                    >
+                      <PencilSimpleIcon size={18} />
+                    </button>
+                    <button className="btn-icon danger" onClick={() => handleDeleteSnapshot(snapshot.filename)}>
+                      <TrashIcon size={18} />
+                    </button>
+                  </>
+                )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -558,6 +558,88 @@ body {
 }
 
 /* ============================================================
+   SNAPSHOTS
+   ============================================================ */
+
+.snapshot-footer-row {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  min-height: var(--input-min-height);
+}
+
+.snapshot-footer-row .snapshot-activate-btn {
+  margin: 0 auto;
+  z-index: 1;
+}
+
+.snapshot-footer-icons {
+  position: absolute;
+  right: var(--space-2);
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 0.06rem;
+  z-index: 2;
+}
+
+.snapshot-footer-icons .btn-icon {
+  min-width: auto;
+  width: 30px;
+  height: 30px;
+  padding: 0.2rem;
+}
+
+.snapshot-banner {
+  padding: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  border-radius: 0.5rem;
+  background: var(--surface-2);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.snapshot-warning-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  margin-left: var(--space-3);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-negative);
+  color: var(--color-text-inverse);
+  font-weight: 700;
+  font-size: var(--font-xs);
+  white-space: nowrap;
+}
+
+.snapshot-helper-text {
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+  max-width: 680px;
+  line-height: 1.4;
+}
+
+.snapshots-controls {
+  justify-content: flex-start;
+  margin-top: var(--space-2);
+}
+
+.snapshots-controls .input-with-icon {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.snapshots-controls .input-with-icon input {
+  background: transparent;
+}
+
+/* ============================================================
    BUTTONS
    ============================================================ */
 
@@ -885,6 +967,14 @@ body {
   box-shadow: var(--shadow);
   padding: var(--space-6);
   text-align: center;
+  border: 1px solid var(--color-border);
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.summary-card.active {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-1px);
 }
 
 .summary-card h3 {
@@ -1116,6 +1206,27 @@ body {
 
   .main {
     padding: var(--space-4);
+  }
+
+  .snapshot-footer-row {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
+  }
+
+  .snapshot-footer-row .snapshot-activate-btn {
+    margin: 0 auto;
+  }
+
+  .snapshot-footer-icons {
+    position: static;
+    margin: var(--space-1) 0 0;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .snapshot-warning-badge span {
+    display: none;
   }
 
   .nav {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -47,3 +47,15 @@ export interface UpcomingBill {
   tags: string[];
   is_variable: boolean;
 }
+
+export interface SnapshotInfo {
+  filename: string;
+  created_at: string;
+  label?: string;
+}
+
+export interface ActiveSnapshot {
+  filename?: string;
+  label?: string;
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary

This feature adds snapshot/archive support so users can save the current budget state before major updates (e.g., entering items for the new year) and easily revisit it later. The backend stores snapshots as copied SQLite files and supports create, list, activate, reset, delete, and rename operations. The frontend adds a Snapshot page with cards for returning to current, adding, labeling, and removing snapshots, and an active database indicator. The header presents a clear warning if a user is in a snapshot rather than current, to prevent accidental updates to the wrong database.

## Changes

- Backend: snapshot CRUD and activation logic, stores snapshots as SQLite copies
- Frontend: Snapshot page UI, snapshot management, active DB warning in header
- Types and API updates for snapshot support

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes