### PR TITLE
chore: tidy snapshot CSS and mobile layout

### DIFF
--- a/frontend/src/pages/Snapshots.tsx
+++ b/frontend/src/pages/Snapshots.tsx
@@ -67,7 +67,7 @@ export default function Snapshots() {
         <h1>Snapshots</h1>
       </div>
       <p className="snapshot-helper-text">Create a snapshot to save your current values before changing or updating them for a new year. This lets you easily revisit previous bills.</p>
-      <form className="tag-create-form" onSubmit={(e) => { e.preventDefault(); handleCreateSnapshot(); }}>
+      <form className="snapshot-create-form" onSubmit={(e) => { e.preventDefault(); handleCreateSnapshot(); }}>
         <input
           type="text"
           value={label}
@@ -79,18 +79,22 @@ export default function Snapshots() {
         </button>
       </form>
 
-      <p className="summary-value">
+      <p className="snapshot-viewing">
         Viewing: <strong>{active.filename ? activeLabel : 'Current'}</strong>
       </p>
 
-      <div className="summary-cards" style={{ gap: '8px', marginTop: '12px' }}>
+      <div className="snapshot-cards">
 
         <div className={`summary-card ${!active.filename ? 'active' : ''}`}>
           <h3>Current database</h3>
           <p>The active database</p>
-          <button className="btn btn-primary" onClick={handleReset} disabled={isLoading || !active.filename}>
-            Return to Current
-          </button>
+          <div className="snapshot-footer-row">
+            <div />
+            <button className="btn btn-primary" onClick={handleReset} disabled={isLoading || !active.filename}>
+              Return to Current
+            </button>
+            <div />
+          </div>
         </div>
 
         {snapshots.length === 0 && <div className="empty-state">No snapshots yet.</div>}
@@ -108,7 +112,7 @@ export default function Snapshots() {
                     value={editingLabel}
                     onChange={(e) => setEditingLabel(e.target.value)}
                     placeholder="Snapshot label"
-                    className="page-header-search"
+                    className="snapshot-input"
                   />
                 </div>
               ) : (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -561,35 +561,79 @@ body {
    SNAPSHOTS
    ============================================================ */
 
+.snapshot-helper-text {
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+  margin-bottom: var(--space-4);
+}
+
+.snapshot-create-form {
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+
+.snapshot-create-form input {
+  flex: 1;
+  padding: var(--space-3) var(--space-4);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-base);
+}
+
+.snapshot-input {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  min-height: var(--space-11);
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-base);
+  line-height: var(--space-11);
+  padding: 0;
+}
+
+.snapshot-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+ 
+.summary-card.active {
+  border: 2px solid var(--color-accent);
+}
+ 
 .snapshot-footer-row {
-  position: relative;
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  margin: 0;
-  min-height: var(--input-min-height);
+  margin-top: var(--space-4);
+  gap: var(--space-2);
 }
-
-.snapshot-footer-row .snapshot-activate-btn {
-  margin: 0 auto;
-  z-index: 1;
+ 
+.snapshot-activate-btn {
+  grid-column: 2;
 }
-
+ 
 .snapshot-footer-icons {
-  position: absolute;
-  right: var(--space-2);
-  top: 50%;
-  transform: translateY(-50%);
+  grid-column: 3;
   display: flex;
-  gap: 0.06rem;
-  z-index: 2;
+  justify-content: flex-end;
+  gap: var(--space-1);
 }
-
-.snapshot-footer-icons .btn-icon {
-  min-width: auto;
-  width: 30px;
-  height: 30px;
-  padding: 0.2rem;
+ 
+.snapshot-viewing {
+  font-size: var(--font-base);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
 }
 
 .snapshot-banner {
@@ -614,29 +658,6 @@ body {
   font-weight: 700;
   font-size: var(--font-xs);
   white-space: nowrap;
-}
-
-.snapshot-helper-text {
-  margin-top: var(--space-2);
-  margin-bottom: var(--space-4);
-  color: var(--color-text-muted);
-  font-size: var(--font-sm);
-  max-width: 680px;
-  line-height: 1.4;
-}
-
-.snapshots-controls {
-  justify-content: flex-start;
-  margin-top: var(--space-2);
-}
-
-.snapshots-controls .input-with-icon {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-}
-
-.snapshots-controls .input-with-icon input {
-  background: transparent;
 }
 
 /* ============================================================
@@ -1208,21 +1229,10 @@ body {
     padding: var(--space-4);
   }
 
-  .snapshot-footer-row {
-    flex-wrap: wrap;
-    justify-content: center;
+  .snapshot-cards {
+    display: grid;
+    grid-template-columns: 1fr;
     gap: var(--space-2);
-  }
-
-  .snapshot-footer-row .snapshot-activate-btn {
-    margin: 0 auto;
-  }
-
-  .snapshot-footer-icons {
-    position: static;
-    margin: var(--space-1) 0 0;
-    width: 100%;
-    justify-content: center;
   }
 
   .snapshot-warning-badge span {


### PR DESCRIPTION
## Summary

Tidied the snapshot CSS and mobile view; removed cross-page class reuse, replaced hardcoded values with tokens where possible, and improved formatting.

## Changes

- CSS cleanup for snapshot section
- Mobile snapshot styles improved
- Use token system rather than hardcoded values

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes