### PR TITLE
feat: optional toggle to hide budget items from Sankey diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Open `http://localhost:3001`. Data persists to `./data/budget.db`.
 | GET | /api/cashflow | Get Sankey diagram data |
 | GET | /api/upcoming-bills | Get upcoming bills |
 | PATCH | /api/budget-items/:id/primary-tag | Set a budget item primary tag (adds to tags if needed) |
+| PATCH | /api/budget-items/:id/visibility | Set a budget item visibility (true=show in Sankey, false=hide) |
 
 ## Normalization
 

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -53,6 +53,10 @@ fn initialize_schema(conn: &Connection) {
     )
     .ok();
     conn.execute_batch(
+        "ALTER TABLE budget_items ADD COLUMN visible INTEGER NOT NULL DEFAULT 1",
+    )
+    .ok();
+    conn.execute_batch(
         "UPDATE budget_items
         SET primary_tag = (
             SELECT t.name FROM tags t

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -9,7 +9,7 @@ use std::{collections::{HashMap, HashSet}, fs, path::PathBuf, time::{SystemTime,
 use crate::db::Db;
 use crate::models::*;
 
-type BudgetItemRow = (i64, String, f64, String, String, Option<i32>, Option<String>, String, String);
+type BudgetItemRow = (i64, String, f64, String, String, Option<i32>, Option<String>, String, bool, String);
 
 // --- Normalization ---
 
@@ -74,6 +74,7 @@ fn build_budget_item(
     day_of_month: Option<i32>,
     notes: Option<String>,
     primary_tag: String,
+    visible: bool,
     created_at: String,
 ) -> BudgetItem {
     let tags = get_item_tags(conn, id);
@@ -99,6 +100,7 @@ fn build_budget_item(
         },
         monthly_amount,
         primary_tag,
+        visible,
         created_at,
     }
 }
@@ -156,7 +158,7 @@ pub async fn list_budget_items(State(db): State<Db>) -> Result<Json<Vec<BudgetIt
 
     let mut stmt = db
         .prepare(
-            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at \
+            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at \
              FROM budget_items ORDER BY created_at DESC",
         )
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -171,7 +173,8 @@ pub async fn list_budget_items(State(db): State<Db>) -> Result<Json<Vec<BudgetIt
                 row.get::<_, Option<i32>>(5)?,
                 row.get::<_, Option<String>>(6)?,
                 row.get::<_, String>(7)?,
-                row.get::<_, String>(8)?,
+                row.get::<_, bool>(8)?,
+                row.get::<_, String>(9)?,
             ))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
@@ -182,8 +185,8 @@ pub async fn list_budget_items(State(db): State<Db>) -> Result<Json<Vec<BudgetIt
     let result = items
         .into_iter()
         .map(
-            |(id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at)| {
-                build_budget_item(&db, id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at)
+            |(id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at)| {
+                build_budget_item(&db, id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at)
             },
         )
         .collect();
@@ -244,6 +247,7 @@ pub async fn create_budget_item(
         input.day_of_month,
         input.notes,
         input.primary_tag,
+        true,
         created_at,
     );
 
@@ -256,9 +260,9 @@ pub async fn get_budget_item(
 ) -> Result<Json<BudgetItem>, StatusCode> {
     let db = get_db_conn(&db).await?;
 
-    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at): BudgetItemRow =
+    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at): BudgetItemRow =
         db.query_row(
-            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at \
+            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at \
              FROM budget_items WHERE id = ?1",
             [id],
             |row| {
@@ -271,7 +275,8 @@ pub async fn get_budget_item(
                     row.get::<_, Option<i32>>(5)?,
                     row.get::<_, Option<String>>(6)?,
                     row.get::<_, String>(7)?,
-                    row.get::<_, String>(8)?,
+                    row.get::<_, bool>(8)?,
+                    row.get::<_, String>(9)?,
                 ))
             },
         )
@@ -287,6 +292,7 @@ pub async fn get_budget_item(
         day_of_month,
         notes,
         primary_tag,
+        visible,
         created_at,
     )))
 }
@@ -337,13 +343,13 @@ pub async fn update_budget_item(
         .ok();
     save_variable_amounts(&db, id, &input.variable_amounts);
 
-    let created_at = db
+    let (created_at, visible): (String, bool) = db
         .query_row(
-            "SELECT created_at FROM budget_items WHERE id = ?1",
+            "SELECT created_at, visible FROM budget_items WHERE id = ?1",
             [id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?)),
         )
-        .unwrap_or_default();
+        .unwrap_or_else(|_| (String::new(), true));
 
     Ok(Json(build_budget_item(
         &db,
@@ -355,6 +361,7 @@ pub async fn update_budget_item(
         input.day_of_month,
         input.notes,
         input.primary_tag,
+        visible,
         created_at,
     )))
 }
@@ -405,9 +412,9 @@ pub async fn update_budget_item_primary_tag(
     )
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag_val, created_at): BudgetItemRow =
+    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag_val, visible, created_at): BudgetItemRow =
         db.query_row(
-            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, created_at FROM budget_items WHERE id = ?1",
+            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at FROM budget_items WHERE id = ?1",
             [id],
             |row| {
                 Ok((
@@ -419,7 +426,8 @@ pub async fn update_budget_item_primary_tag(
                     row.get::<_, Option<i32>>(5)?,
                     row.get::<_, Option<String>>(6)?,
                     row.get::<_, String>(7)?,
-                    row.get::<_, String>(8)?,
+                    row.get::<_, bool>(8)?,
+                    row.get::<_, String>(9)?,
                 ))
             },
         )
@@ -435,6 +443,61 @@ pub async fn update_budget_item_primary_tag(
         day_of_month,
         notes,
         primary_tag_val,
+        visible,
+        created_at,
+    )))
+}
+
+pub async fn update_budget_item_visibility(
+    State(db): State<Db>,
+    Path(id): Path<i64>,
+    Json(input): Json<UpdateVisibility>,
+) -> Result<Json<BudgetItem>, StatusCode> {
+    let db = get_db_conn(&db).await?;
+
+    let changes = db
+        .execute(
+            "UPDATE budget_items SET visible = ?1 WHERE id = ?2",
+            rusqlite::params![input.visible, id],
+        )
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if changes == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let (id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at): BudgetItemRow =
+        db.query_row(
+            "SELECT id, name, amount, item_type, frequency, day_of_month, notes, primary_tag, visible, created_at FROM budget_items WHERE id = ?1",
+            [id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, f64>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, Option<i32>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, bool>(8)?,
+                    row.get::<_, String>(9)?,
+                ))
+            },
+        )
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    Ok(Json(build_budget_item(
+        &db,
+        id,
+        name,
+        amount,
+        item_type,
+        frequency,
+        day_of_month,
+        notes,
+        primary_tag,
+        visible,
         created_at,
     )))
 }
@@ -729,7 +792,7 @@ pub async fn get_cashflow(State(db): State<Db>) -> Result<Json<SankeyData>, Stat
     let db = get_db_conn(&db).await?;
 
     let mut stmt = db
-        .prepare("SELECT id, name, amount, item_type, frequency, primary_tag FROM budget_items")
+        .prepare("SELECT id, name, amount, item_type, frequency, primary_tag FROM budget_items WHERE visible = 1")
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let items: Vec<(i64, String, f64, String, String, String)> = stmt.query_map([], |row| {
         Ok((

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -36,6 +36,10 @@ async fn main() {
             axum::routing::patch(handlers::update_budget_item_primary_tag),
         )
         .route(
+            "/api/budget-items/:id/visibility",
+            axum::routing::patch(handlers::update_budget_item_visibility),
+        )
+        .route(
             "/api/tags",
             get(handlers::list_tags).post(handlers::create_tag),
         )

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -13,6 +13,7 @@ pub struct BudgetItem {
     pub variable_amounts: Option<Vec<VariableAmount>>,
     pub monthly_amount: f64,
     pub primary_tag: String,
+    pub visible: bool,
     pub created_at: String,
 }
 
@@ -32,6 +33,11 @@ pub struct CreateBudgetItem {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpdatePrimaryTag {
     pub primary_tag: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateVisibility {
+    pub visible: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/backend/src/schema.sql
+++ b/backend/src/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS budget_items (
     day_of_month INTEGER,
     notes TEXT,
     primary_tag TEXT NOT NULL DEFAULT '',
+    visible INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -38,6 +38,15 @@ export async function updateBudgetItemPrimaryTag(id: number, primary_tag: string
   return res.json();
 }
 
+export async function updateItemVisibility(id: number, visible: boolean): Promise<BudgetItem> {
+  const res = await fetch(`${API}/budget-items/${id}/visibility`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ visible }),
+  });
+  return res.json();
+}
+
 export async function fetchTags(): Promise<Tag[]> {
   const res = await fetch(`${API}/tags`);
   return res.json();

--- a/frontend/src/pages/BudgetItems.tsx
+++ b/frontend/src/pages/BudgetItems.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
-import { fetchBudgetItems, deleteBudgetItem, updateBudgetItemPrimaryTag } from '../api';
+import { fetchBudgetItems, deleteBudgetItem, updateBudgetItemPrimaryTag, updateItemVisibility } from '../api';
 import type { BudgetItem } from '../types';
 import BudgetItemForm from '../components/BudgetItemForm';
-import { PlusIcon, TrashIcon, PencilSimpleIcon, FunnelSimpleIcon, MagnifyingGlassIcon } from '@phosphor-icons/react';
+import { EyeIcon, EyeSlashIcon, PlusIcon, TrashIcon, PencilSimpleIcon, FunnelSimpleIcon, MagnifyingGlassIcon } from '@phosphor-icons/react';
 
 export default function BudgetItems() {
   const [items, setItems] = useState<BudgetItem[]>([]);
@@ -18,6 +18,11 @@ export default function BudgetItems() {
 
   const handleDelete = async (id: number) => {
     await deleteBudgetItem(id);
+    load();
+  };
+
+  const toggleVisibility = async (id: number, visible: boolean) => {
+    await updateItemVisibility(id, !visible);
     load();
   };
 
@@ -115,7 +120,7 @@ export default function BudgetItems() {
 
       <div className="items-grid">
         {visibleItems.map((item) => (
-          <div key={item.id} className={`item-card ${item.item_type}`}>
+          <div key={item.id} className={`item-card ${item.item_type} ${item.visible ? '' : 'item-card-hidden'}`}>
             <div className="item-card-header">
               <span className="item-name">{item.name}</span>
               <span className={`item-amount ${item.item_type}`}>
@@ -151,6 +156,13 @@ export default function BudgetItems() {
             )}
             {item.notes && <p className="item-notes">{item.notes}</p>}
             <div className="item-actions">
+              <button
+                className="btn-icon"
+                onClick={() => toggleVisibility(item.id, item.visible)}
+                title={item.visible ? 'Hide from Sankey' : 'Show in Sankey'}
+              >
+                {item.visible ? <EyeIcon size={18} /> : <EyeSlashIcon size={18} />}
+              </button>
               <button
                 className="btn-icon"
                 onClick={() => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -501,6 +501,11 @@ body {
   border-left-color: var(--color-negative);
 }
 
+.item-card-hidden {
+  opacity: 0.5;
+  color: var(--color-text-muted);
+}
+
 .item-card-header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,7 @@ export interface BudgetItem {
   variable_amounts?: VariableAmount[];
   monthly_amount: number;
   primary_tag: string;
+  visible: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Adds an optional toggle so users can hide specific budget items from appearing in the Sankey diagram.

## Changes

- Backend support for hidden items flag on budget items
- Frontend toggle control in budget item row and Sankey filter logic
- Updated API/types/schema for hidden items

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes