### PR TITLE
feat: add tooltip showing value on Sankey nodes for easier hover

### DIFF
--- a/frontend/src/components/BudgetDiagram.tsx
+++ b/frontend/src/components/BudgetDiagram.tsx
@@ -13,6 +13,13 @@ const SankeyTooltip = ({ link }: { link: any }) => (
   </div>
 );
 
+const SankeyNodeTooltip = ({ node }: { node: any }) => (
+  <div className="sankey-tooltip">
+    <strong>{node.label}</strong>
+    <div className="sankey-tooltip-value">${node.value.toLocaleString()}</div>
+  </div>
+);
+
 const nivoTheme = {
   text: {
     fill: 'var(--color-text)',
@@ -64,6 +71,7 @@ export default function BudgetDiagram({ data }: Props) {
         labelPadding={16}
         labelTextColor="var(--color-text)"
         linkTooltip={SankeyTooltip}
+        nodeTooltip={SankeyNodeTooltip}
         theme={nivoTheme}
       />
     </div>


### PR DESCRIPTION
## Summary

Add a tooltip on Sankey nodes with the value display for easier hover access on thin lines.

## Changes

- Sankey node tooltip now shows numeric value when hovered

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes