### PR TITLE
chore: align nav brand icon size

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,12 @@ export default function App() {
         <div className="app">
           <nav className="nav">
             <div className="nav-brand">
-              <img src="/icon-192.png" alt="" aria-hidden="true" />
+              <img
+                src="/icon-192.png"
+                alt=""
+                aria-hidden="true"
+                style={{ width: '24px', height: '24px' }}
+              />
               <span>Budget Overview</span>
             </div>
             {activeSnapshot && activeSnapshotTitle && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ export default function App() {
                 src="/icon-192.png"
                 alt=""
                 aria-hidden="true"
-                style={{ width: '24px', height: '24px' }}
+                style={{ width: '20px', height: '20px' }}
               />
               <span>Budget Overview</span>
             </div>


### PR DESCRIPTION
## Summary
- Align nav brand icon size with nav item icons in header

## Changes
- frontend/src/App.tsx: changed <img src="/icon-192.png"> to style={{ width: '20px', height: '20px' }}

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes