### PR TITLE
chore: use WarningCircleIcon for snapshot badge

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
-import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon, BoxArrowDownIcon, WarningCircle } from '@phosphor-icons/react'
+import { HouseIcon, ListBulletsIcon, ChartBarIcon, TagIcon, BoxArrowDownIcon, WarningCircleIcon } from '@phosphor-icons/react'
 import Dashboard from './pages/Dashboard'
 import BudgetItems from './pages/BudgetItems'
 import Summary from './pages/Summary'
@@ -45,7 +45,7 @@ export default function App() {
             </div>
             {activeSnapshot && activeSnapshotTitle && (
               <div className="snapshot-warning-badge" role="status" aria-live="polite">
-                <WarningCircle size={16} /> <span>Snapshot active: {activeSnapshotTitle}</span>
+                <WarningCircleIcon size={16} /> <span>Snapshot active: {activeSnapshotTitle}</span>
               </div>
             )}
             <div className="nav-links">


### PR DESCRIPTION
## Summary
- Replace deprecated phosphor icon WarningCircle with WarningCircleIcon in snapshot badge.

## Changes
- frontend/src/App.tsx: replaced WarningCircle with WarningCircleIcon

## Validation
- [x] cargo check --manifest-path backend/Cargo.toml
- [x] cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
- [x] npm run build --prefix frontend

## Notes
- [x] No breaking changes