### PR TITLE
fix: use relative API URL in browser, keep absolute for Tauri

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type { BudgetItem, CreateBudgetItem, Tag, SankeyData, UpcomingBill, SnapshotInfo, ActiveSnapshot } from './types';
 
-const API = 'http://127.0.0.1:3001/api';
+const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
+const API = isTauri ? 'http://127.0.0.1:3001/api' : '/api';
 
 export async function fetchBudgetItems(): Promise<BudgetItem[]> {
   const res = await fetch(`${API}/budget-items`);


### PR DESCRIPTION
## Summary
- Fix API base URL so Docker deployments work when accessed from any machine

## Changes
- Detect Tauri context via \`window.__TAURI__\` and use \`http://127.0.0.1:3001/api\` only inside the desktop app; all other environments use relative \`/api\`

## Validation
- [x] \`cargo check --manifest-path backend/Cargo.toml\`
- [x] \`cargo clippy --manifest-path backend/Cargo.toml -- -D warnings\`
- [x] \`npm run build --prefix frontend\`

## Notes
- [x] No breaking changes