### PR TITLE
feat: add yearly dashboard toggle and yearly values

### DIFF
--- a/frontend/src/pages/BudgetItems.tsx
+++ b/frontend/src/pages/BudgetItems.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { fetchBudgetItems, deleteBudgetItem, updateBudgetItemPrimaryTag, updateItemVisibility } from '../api';
+import { getYearlyAmount } from '../utils';
 import type { BudgetItem } from '../types';
 import BudgetItemForm from '../components/BudgetItemForm';
 import { EyeIcon, EyeSlashIcon, PlusIcon, TrashIcon, PencilSimpleIcon, FunnelSimpleIcon, MagnifyingGlassIcon } from '@phosphor-icons/react';
@@ -123,13 +124,20 @@ export default function BudgetItems() {
           <div key={item.id} className={`item-card ${item.item_type} ${item.visible ? '' : 'item-card-hidden'}`}>
             <div className="item-card-header">
               <span className="item-name">{item.name}</span>
-              <span className={`item-amount ${item.item_type}`}>
-                {item.item_type === 'income' ? '+' : '-'}${item.monthly_amount.toFixed(2)}/mo
-              </span>
+              <div className="item-amount-stack">
+                <span className={`item-amount ${item.item_type}`}>
+                  {item.item_type === 'income' ? '+' : '-'}${item.monthly_amount.toFixed(2)}/mo
+                </span>
+                <span className={`item-amount-yearly ${item.item_type}`}>
+                  ${getYearlyAmount(item).toLocaleString('en-CA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/yr
+                </span>
+              </div>
             </div>
             <div className="item-card-meta">
-              <span className="item-frequency">{item.frequency}</span>
-              {item.day_of_month && <span>Day {item.day_of_month}</span>}
+              <div className="item-card-meta-top">
+                <span className="item-frequency">{item.frequency}</span>
+                {item.day_of_month && <span>Day {item.day_of_month}</span>}
+              </div>
             </div>
             {item.tags.length > 0 && (
               <div className="item-tags">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,26 +1,49 @@
-import { useState, useEffect } from 'react';
-import { fetchCashflow } from '../api';
-import type { SankeyData } from '../types';
+import { useState, useEffect, useMemo } from 'react';
+import { fetchCashflow, fetchBudgetItems } from '../api';
+import type { BudgetItem, SankeyData } from '../types';
+import { buildYearlySankeyData } from '../utils';
 import BudgetDiagram from '../components/BudgetDiagram';
 import UpcomingBillsSidebar from '../components/UpcomingBillsSidebar';
 
 export default function Dashboard() {
-  const [data, setData] = useState<SankeyData | null>(null);
+  const [viewMode, setViewMode] = useState<'monthly' | 'yearly'>('monthly');
+  const [monthlyData, setMonthlyData] = useState<SankeyData | null>(null);
+  const [budgetItems, setBudgetItems] = useState<BudgetItem[]>([]);
 
   useEffect(() => {
-    fetchCashflow().then(setData);
+    fetchCashflow().then(setMonthlyData);
+    fetchBudgetItems().then(setBudgetItems);
   }, []);
+
+  const yearlyData = useMemo(() => buildYearlySankeyData(budgetItems), [budgetItems]);
+  const data = viewMode === 'monthly' ? monthlyData : yearlyData;
 
   return (
     <>
-      <h1 className="dashboard-title">Monthly Budget</h1>
+      <h1 className="dashboard-title">Budget</h1>
+      <div className="dashboard-controls">
+        <div className="btn-group">
+          <button
+            className={`btn ${viewMode === 'monthly' ? 'active' : ''}`}
+            onClick={() => setViewMode('monthly')}
+          >
+            Monthly
+          </button>
+          <button
+            className={`btn ${viewMode === 'yearly' ? 'active' : ''}`}
+            onClick={() => setViewMode('yearly')}
+          >
+            Yearly
+          </button>
+        </div>
+      </div>
       <div className="dashboard">
         <div className="dashboard-main">
           {data && data.nodes.length > 0 ? (
             <BudgetDiagram data={data} />
           ) : (
             <div className="empty-state">
-              <p>No budget items yet. Add income and expenses to see your monthly budget.</p>
+              <p>No budget items yet. Add income and expenses to see your {viewMode} budget.</p>
             </div>
           )}
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -470,6 +470,10 @@ body {
   min-width: 0;
 }
 
+.dashboard-controls {
+  margin-bottom: var(--space-4);
+}
+
 .sankey-container {
   height: var(--chart-height);
   background: var(--color-surface);
@@ -697,15 +701,16 @@ body {
 }
 
 .item-card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  position: relative;
+  padding-right: var(--amounts-min);
   margin-bottom: var(--space-2);
 }
 
 .item-name {
   font-weight: 700;
   font-size: var(--font-lg);
+  word-break: break-word;
+  padding-right: var(--space-3);
 }
 
 .item-amount {
@@ -721,12 +726,44 @@ body {
   color: var(--color-negative);
 }
 
+.item-amount-stack {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+
+.item-amount-yearly {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.item-amount-yearly.income {
+  color: var(--color-positive);
+}
+
+.item-amount-yearly.expense {
+  color: var(--color-negative);
+}
+
 .item-card-meta {
   display: flex;
-  gap: var(--space-3);
+  flex-direction: column;
+  gap: var(--space-2);
   font-size: var(--font-sm);
   color: var(--color-text-muted);
   margin-bottom: var(--space-2);
+}
+
+.item-card-meta-top {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
 }
 
 .item-frequency {

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,89 @@
+import type { BudgetItem, SankeyData } from './types';
+
+export function getYearlyAmount(item: BudgetItem): number {
+  if (item.frequency === 'yearly') {
+    return item.amount;
+  }
+
+  if (item.variable_amounts?.length) {
+    return item.variable_amounts.reduce((sum, entry) => sum + entry.amount, 0);
+  }
+
+  return item.monthly_amount * 12;
+}
+
+export function buildYearlySankeyData(items: BudgetItem[]): SankeyData {
+  const visibleItems = items.filter((item) => item.visible);
+  const incomeItems = visibleItems.filter((item) => item.item_type === 'income');
+  const expenseItems = visibleItems.filter((item) => item.item_type === 'expense');
+
+  const expenseByTag: Record<string, number> = {};
+  expenseItems.forEach((item) => {
+    const tag = item.primary_tag || 'Misc';
+    expenseByTag[tag] = (expenseByTag[tag] ?? 0) + getYearlyAmount(item);
+  });
+
+  const incomeTotal = incomeItems.reduce((sum, item) => sum + getYearlyAmount(item), 0);
+  const expenseTotal = Object.values(expenseByTag).reduce((sum, amount) => sum + amount, 0);
+
+  if (incomeTotal === 0 && expenseTotal === 0) {
+    return { nodes: [], links: [] };
+  }
+
+  const nodes: { id: string }[] = [];
+  const links: { source: string; target: string; value: number }[] = [];
+  const budgetNode = 'Budget';
+
+  const nodeIds = new Set<string>();
+
+  incomeItems.forEach((item) => {
+    const source = item.name;
+    if (!nodeIds.has(source)) {
+      nodes.push({ id: source });
+      nodeIds.add(source);
+    }
+
+    links.push({
+      source,
+      target: budgetNode,
+      value: getYearlyAmount(item),
+    });
+  });
+
+  if (!nodeIds.has(budgetNode)) {
+    nodes.push({ id: budgetNode });
+    nodeIds.add(budgetNode);
+  }
+
+  Object.entries(expenseByTag).forEach(([tag, amount]) => {
+    if (!nodeIds.has(tag)) {
+      nodes.push({ id: tag });
+      nodeIds.add(tag);
+    }
+
+    links.push({
+      source: budgetNode,
+      target: tag,
+      value: amount,
+    });
+  });
+
+  const diff = incomeTotal - expenseTotal;
+  if (diff > 0) {
+    nodes.push({ id: 'Remaining' });
+    links.push({
+      source: budgetNode,
+      target: 'Remaining',
+      value: diff,
+    });
+  } else if (diff < 0) {
+    nodes.push({ id: 'Deficit' });
+    links.push({
+      source: budgetNode,
+      target: 'Deficit',
+      value: Math.abs(diff),
+    });
+  }
+
+  return { nodes, links };
+}


### PR DESCRIPTION
Adds a yearly view toggle to the dashboard diagram and displays yearly amounts on each budget item card. Yearly values are derived from the explicit yearly amount, the sum of variable amounts when provided, or monthly amounts otherwise. 